### PR TITLE
chore: use GitHub Pages base URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -768,7 +768,7 @@
 
     <script>
         // Configuration
-        const VIEWER_URL = 'https://sites.google.com/view/securecontact/';
+        const VIEWER_URL = 'https://clovenbradshaw-ctrl.github.io/safety/';
         const BEACON_TEXT = 'SQR:1';
         const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook-test/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
         const ARCHIVE_BASE = 'https://archive.org/download/zuboff/';


### PR DESCRIPTION
## Summary
- point `VIEWER_URL` to GitHub Pages domain for generating QR links

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ad2b86c94c8332ba6ad047432c1bb1