### PR TITLE
Fix banner overlapping top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             flex-direction: column;
             align-items: center !important;
             justify-content: flex-start !important;
-            padding-top: 60px;
+            padding-top: 60px !important;
         }
 
         .container {


### PR DESCRIPTION
## Summary
- Ensure banner is visible below fixed top bar by forcing body top padding

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68ade354831c8332a63517321dca05c6