### PR TITLE
Increase top padding for fixed header overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             flex-direction: column;
             align-items: center !important;
             justify-content: flex-start !important;
-            padding-top: 60px !important;
+            padding-top: 80px !important;
         }
 
         .container {
@@ -545,7 +545,7 @@
         @media (max-width: 480px) {
             body {
                 /* Maintain space for fixed top menu */
-                padding: 60px 10px 10px;
+                padding: 80px 10px 10px;
             }
             
             .container {


### PR DESCRIPTION
## Summary
- increase body top padding to 80px to avoid overlap with fixed header
- adjust mobile padding to maintain spacing beneath top menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ade57806108332a6503daadf62aca2