### PR TITLE
Add Text-to-911 location tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,6 +863,7 @@ body.rtl .info-icon {
     </style>
 </head>
 <body>
+<div id="qrTab">
     <div class="top-bar">
         <div class="logo">🚨 <span class="logo-text-full">Emergency QR</span><span class="logo-text-short">QR</span></div>
         <div class="controls">
@@ -2379,5 +2380,25 @@ body.rtl .info-icon {
             }, 500);
         });
     </script>
+</div>
+<div id="text911Tab" style="display:none;">
+    <iframe src="text911.html" style="border:none;width:100%;height:100vh;"></iframe>
+</div>
+<nav class="tab-bar" style="position:fixed;bottom:0;left:0;right:0;display:flex;background:#fff;border-top:1px solid #ccc;z-index:1000;">
+    <button id="qrTabBtn" style="flex:1;padding:10px;">QR</button>
+    <button id="text911TabBtn" style="flex:1;padding:10px;">911 Location</button>
+</nav>
+<script>
+    const qrTab = document.getElementById('qrTab');
+    const text911Tab = document.getElementById('text911Tab');
+    document.getElementById('qrTabBtn').addEventListener('click', () => {
+        qrTab.style.display = 'block';
+        text911Tab.style.display = 'none';
+    });
+    document.getElementById('text911TabBtn').addEventListener('click', () => {
+        qrTab.style.display = 'none';
+        text911Tab.style.display = 'block';
+    });
+</script>
 </body>
 </html>

--- a/text911.html
+++ b/text911.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Emergency 911 Location</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            padding: 20px;
+        }
+        .container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+            max-width: 400px;
+            width: 100%;
+            overflow: hidden;
+        }
+        .header {
+            background: linear-gradient(135deg, #991b1b 0%, #7f1d1d 100%);
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .header h1 {
+            font-size: 22px;
+            font-weight: 700;
+            margin-bottom: 4px;
+        }
+        .header p {
+            font-size: 13px;
+            opacity: 0.95;
+        }
+        .emergency-buttons {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 12px;
+            padding: 20px;
+            background: #fee2e2;
+            border-bottom: 2px solid #dc2626;
+        }
+        .btn-911 {
+            padding: 20px 16px;
+            border: none;
+            border-radius: 12px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+            text-decoration: none;
+            color: white;
+        }
+        .btn-call {
+            background: linear-gradient(135deg, #059669 0%, #047857 100%);
+        }
+        .btn-call:hover {
+            transform: scale(1.05);
+            box-shadow: 0 8px 20px rgba(5, 150, 105, 0.4);
+        }
+        .btn-text {
+            background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
+        }
+        .btn-text:hover {
+            transform: scale(1.05);
+            box-shadow: 0 8px 20px rgba(59, 130, 246, 0.4);
+        }
+        .btn-911 .icon {
+            font-size: 28px;
+        }
+        .btn-911 .label {
+            font-size: 16px;
+        }
+        .btn-911 .sublabel {
+            font-size: 10px;
+            opacity: 0.9;
+            font-weight: 500;
+        }
+        .content {
+            padding: 20px;
+        }
+        .location-card {
+            margin-bottom: 14px;
+            padding: 14px;
+            background: #f9fafb;
+            border-radius: 10px;
+            border: 1px solid #e5e7eb;
+        }
+        .location-card.primary {
+            background: #ecfdf5;
+            border: 2px solid #10b981;
+        }
+        .card-label {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: #6b7280;
+            margin-bottom: 6px;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .primary .card-label {
+            color: #047857;
+            font-weight: 600;
+        }
+        .card-value {
+            font-size: 15px;
+            font-weight: 600;
+            color: #111827;
+            word-break: break-word;
+            line-height: 1.4;
+        }
+        .card-value.mono {
+            font-family: 'SF Mono', 'Courier New', monospace;
+            font-size: 16px;
+            letter-spacing: 1px;
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 3px 6px;
+            border-radius: 4px;
+            font-size: 9px;
+            font-weight: 700;
+            background: #10b981;
+            color: white;
+        }
+        .copy-btn {
+            width: 100%;
+            padding: 14px;
+            margin-top: 16px;
+            background: white;
+            color: #4b5563;
+            border: 2px solid #d1d5db;
+            border-radius: 10px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .copy-btn:hover {
+            background: #f9fafb;
+            border-color: #6b7280;
+            transform: translateX(2px);
+        }
+        .loading {
+            text-align: center;
+            padding: 60px 20px;
+        }
+        .loading-spinner {
+            border: 3px solid #fee2e2;
+            border-top: 3px solid #dc2626;
+            border-radius: 50%;
+            width: 48px;
+            height: 48px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto 16px;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        .error {
+            background: #fef2f2;
+            color: #991b1b;
+            padding: 16px;
+            border-radius: 12px;
+            margin: 20px;
+            text-align: center;
+        }
+        .toast {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #10b981;
+            color: white;
+            padding: 14px 24px;
+            border-radius: 10px;
+            font-weight: 600;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+            z-index: 2000;
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+        .toast.show { opacity: 1; }
+        .privacy-tooltip {
+            position: fixed;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0,0,0,0.5);
+            z-index: 3000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        .privacy-tooltip-content {
+            background: white;
+            border-radius: 12px;
+            padding: 20px;
+            font-size: 12px;
+            line-height: 1.5;
+            color: #374151;
+            max-width: 300px;
+            position: relative;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+        }
+        .close-privacy {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            width: 24px;
+            height: 24px;
+            line-height: 24px;
+            text-align: center;
+            font-size: 20px;
+            cursor: pointer;
+            color: #6b7280;
+            border-radius: 50%;
+        }
+        .warning-box {
+            background: #fef3c7;
+            border-left: 3px solid #f59e0b;
+            padding: 8px 12px;
+            margin-top: 16px;
+            font-size: 11px;
+            color: #92400e;
+            line-height: 1.4;
+        }
+        .accuracy-indicator {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 12px;
+            color: #6b7280;
+            margin: 12px 0;
+            padding: 8px;
+            background: #f9fafb;
+            border-radius: 8px;
+        }
+        .accuracy-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #10b981;
+            animation: pulse 2s infinite;
+        }
+        @keyframes pulse {
+            0%,100%{opacity:1;}
+            50%{opacity:0.5;}
+        }
+        .accuracy-poor { background:#f59e0b; }
+        @media (max-width:480px){
+            .container{border-radius:0;max-width:100%;}
+            body{padding:0;}
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🚨 Emergency 911 Location</h1>
+            <p>Your exact location for emergency services</p>
+        </div>
+        <div class="emergency-buttons" id="emergencyButtons" style="display:none;">
+            <a href="tel:911" class="btn-911 btn-call">
+                <span class="icon">📞</span>
+                <span class="label">Call 911</span>
+                <span class="sublabel">Voice Call</span>
+            </a>
+            <a href="#" onclick="text911();return false;" class="btn-911 btn-text">
+                <span class="icon">💬</span>
+                <span class="label">Text 911</span>
+                <span class="sublabel">Silent Emergency</span>
+            </a>
+        </div>
+        <div id="loading" class="loading">
+            <div class="loading-spinner"></div>
+            <p>Getting your location...</p>
+        </div>
+        <div id="error" class="error" style="display:none;">
+            <strong>⚠️ Location Required</strong>
+            <p id="errorMessage">Please enable location access</p>
+        </div>
+        <div id="content" class="content" style="display:none;">
+            <div class="location-card primary">
+                <div class="card-label">✅ GPS Coordinates <span class="status-badge">911 UNIVERSAL</span></div>
+                <div class="card-value mono" id="coordinates">Loading...</div>
+            </div>
+            <div class="location-card">
+                <div class="card-label">📍 Nearest Address</div>
+                <div class="card-value" id="address">Locating...</div>
+            </div>
+            <div class="location-card">
+                <div class="card-label">🚦 Cross Streets</div>
+                <div class="card-value" id="crossStreets">Locating...</div>
+            </div>
+            <div class="location-card">
+                <div class="card-label">📱 Plus Code</div>
+                <div class="card-value mono" id="plusCode">Loading...</div>
+            </div>
+            <div class="accuracy-indicator">
+                <div class="accuracy-dot" id="accuracyDot"></div>
+                <span>Accuracy: <strong id="accuracyText">--</strong></span>
+            </div>
+            <button class="copy-btn" onclick="copyAll()">📋 Copy All Location Info</button>
+            <div class="warning-box" id="textWarning">
+                <strong>💬 Text 911:</strong> Checking availability...
+            </div>
+        </div>
+    </div>
+    <div id="toast" class="toast"></div>
+    <script>
+        let currentLocation=null;
+        const CODE_ALPHABET='23456789CFGHJMPQRVWX';
+        const STATE_ABBREVIATIONS={
+            'Alabama':'AL','Alaska':'AK','Arizona':'AZ','Arkansas':'AR','California':'CA','Colorado':'CO','Connecticut':'CT',
+            'Delaware':'DE','District of Columbia':'DC','Florida':'FL','Georgia':'GA','Hawaii':'HI','Idaho':'ID','Illinois':'IL',
+            'Indiana':'IN','Iowa':'IA','Kansas':'KS','Kentucky':'KY','Louisiana':'LA','Maine':'ME','Maryland':'MD','Massachusetts':'MA',
+            'Michigan':'MI','Minnesota':'MN','Mississippi':'MS','Missouri':'MO','Montana':'MT','Nebraska':'NE','Nevada':'NV',
+            'New Hampshire':'NH','New Jersey':'NJ','New Mexico':'NM','New York':'NY','North Carolina':'NC','North Dakota':'ND',
+            'Ohio':'OH','Oklahoma':'OK','Oregon':'OR','Pennsylvania':'PA','Rhode Island':'RI','South Carolina':'SC','South Dakota':'SD',
+            'Tennessee':'TN','Texas':'TX','Utah':'UT','Vermont':'VT','Virginia':'VA','Washington':'WA','West Virginia':'WV',
+            'Wisconsin':'WI','Wyoming':'WY','Puerto Rico':'PR'
+        };
+        const textingDataPromise=fetch('911-texting.json').then(r=>r.json());
+
+        function encodePlusCode(latitude,longitude){
+            latitude=Math.max(-90,Math.min(90,latitude));
+            longitude=Math.max(-180,Math.min(180,longitude));
+            latitude+=90;longitude+=180;let code='';
+            const gridSizes=[20,1,0.05,0.0025,0.000125];
+            for(let i=0;i<5;i++){
+                const latIndex=Math.floor(latitude/gridSizes[i])%20;
+                const lngIndex=Math.floor(longitude/gridSizes[i])%20;
+                code+=CODE_ALPHABET[latIndex]+CODE_ALPHABET[lngIndex];
+            }
+            return code.slice(0,8)+'+'+code.slice(8);
+        }
+        function showToast(msg){const t=document.getElementById('toast');t.textContent=msg;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),3000);}
+        function text911(){if(currentLocation){const message=`EMERGENCY AT:\nGPS: ${currentLocation.latitude}, ${currentLocation.longitude}\nAddress: ${currentLocation.address}\nCross Streets: ${currentLocation.crossStreets}\nPlus Code: ${currentLocation.plusCode}\nMaps: https://maps.google.com/?q=${currentLocation.latitude},${currentLocation.longitude}\n\n[Describe your emergency]`;const smsLink=`sms:911?body=${encodeURIComponent(message)}`;window.location.href=smsLink;setTimeout(()=>{showToast('Opening YOUR text app - add details & send to 911');},500);}else{showToast('Location still loading... Please wait');}}
+        function copyAll(){if(currentLocation){const allInfo=`🚨 EMERGENCY LOCATION\n\nGPS (FOR 911): ${currentLocation.latitude}, ${currentLocation.longitude}\nADDRESS: ${currentLocation.address}\nCROSS STREETS: ${currentLocation.crossStreets}\nPLUS CODE: ${currentLocation.plusCode}\nGOOGLE MAPS: https://maps.google.com/?q=${currentLocation.latitude},${currentLocation.longitude}\nACCURACY: ${currentLocation.accuracyText}`;navigator.clipboard.writeText(allInfo).then(()=>showToast('Location copied! You can now paste & share it')).catch(()=>{const t=document.createElement('textarea');t.value=allInfo;document.body.appendChild(t);t.select();document.execCommand('copy');document.body.removeChild(t);showToast('Location copied! You can now paste & share it');});}}
+        async function reverseGeocode(lat,lon){try{const response=await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}&zoom=18&addressdetails=1`);if(response.ok)return await response.json();}catch(e){console.error('Geocoding error:',e);}return null;}
+        function formatAddress(data){if(!data||!data.address)return'Unable to determine';const addr=data.address;const parts=[];if(addr.house_number)parts.push(addr.house_number);if(addr.road||addr.street)parts.push(addr.road||addr.street);if(!parts.length&&addr.building)parts.push(addr.building);const city=addr.city||addr.town||addr.village||addr.suburb;if(city)parts.push(city);if(addr.state)parts.push(addr.state);if(addr.postcode)parts.push(addr.postcode);return parts.join(', ')||data.display_name||'Unable to determine';}
+        async function findCrossStreets(lat,lon,data){if(!data||!data.address)return'Unable to determine';const currentRoad=data.address.road||data.address.street||'';if(currentRoad){try{const offset=0.001;const nearbyResponse=await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat+offset}&lon=${lon+offset}&zoom=18&addressdetails=1`);if(nearbyResponse.ok){const nearbyData=await nearbyResponse.json();const nearbyRoad=nearbyData.address?.road||nearbyData.address?.street||'';if(nearbyRoad&&nearbyRoad!==currentRoad){return `${currentRoad} & ${nearbyRoad}`;}}}catch(e){console.error('Cross streets error:',e);}return `Near ${currentRoad}`;}return'Unable to determine';}
+        async function updateDisplay(position){const lat=position.coords.latitude;const lon=position.coords.longitude;const accuracy=position.coords.accuracy;document.getElementById('emergencyButtons').style.display='grid';const coordsText=`${lat.toFixed(6)}, ${lon.toFixed(6)}`;document.getElementById('coordinates').textContent=coordsText;const plusCode=encodePlusCode(lat,lon);document.getElementById('plusCode').textContent=plusCode;let accuracyText='',accuracyClass='';if(accuracy<=15){accuracyText=`Excellent (±${Math.round(accuracy)}m)`;}else if(accuracy<=50){accuracyText=`Good (±${Math.round(accuracy)}m)`;}else{accuracyText=`Approximate (±${Math.round(accuracy)}m)`;accuracyClass='accuracy-poor';}document.getElementById('accuracyText').textContent=accuracyText;document.getElementById('accuracyDot').className=`accuracy-dot ${accuracyClass}`;const geoData=await reverseGeocode(lat,lon);const address=formatAddress(geoData);const crossStreets=await findCrossStreets(lat,lon,geoData);document.getElementById('address').textContent=address;document.getElementById('crossStreets').textContent=crossStreets;const textingData=await textingDataPromise;const stateFull=geoData?.address?.state||'';const countyFull=geoData?.address?.county||'';const stateCode=STATE_ABBREVIATIONS[stateFull]||'';const county=countyFull.replace(/ County| Parish| Census Area| Borough| Municipality/gi,'').trim();const textAvailable=textingData.some(e=>e.State===stateCode&&e.County===county);const textBtn=document.querySelector('.btn-text');const warning=document.getElementById('textWarning');if(textAvailable){textBtn.style.display='flex';warning.innerHTML='<strong>💬 Text 911:</strong> Available in this area';}else{textBtn.style.display='none';warning.innerHTML='<strong>💬 Text 911:</strong> Not available here';}
+            currentLocation={latitude:lat.toFixed(6),longitude:lon.toFixed(6),plusCode:plusCode,address:address,crossStreets:crossStreets,accuracyText:accuracyText};
+            document.getElementById('loading').style.display='none';
+            document.getElementById('content').style.display='block';
+            document.getElementById('error').style.display='none';
+        }
+        function showError(error){let message='';switch(error.code){case error.PERMISSION_DENIED:message="Location access denied. Please enable it and refresh.";break;case error.POSITION_UNAVAILABLE:message="Location unavailable. Please try again.";break;case error.TIMEOUT:message="Location request timed out. Please refresh.";break;default:message="Unable to get location. Please refresh.";}document.getElementById('errorMessage').textContent=message;document.getElementById('loading').style.display='none';document.getElementById('content').style.display='none';document.getElementById('emergencyButtons').style.display='none';document.getElementById('error').style.display='block';}
+        function getLocation(){if(navigator.geolocation){navigator.geolocation.getCurrentPosition(updateDisplay,showError,{enableHighAccuracy:true,timeout:15000,maximumAge:0});navigator.geolocation.watchPosition(updateDisplay,()=>{},{enableHighAccuracy:true,maximumAge:10000});}else{showError({code:0,message:"Geolocation not supported"});}}
+        window.onload=function(){getLocation();};
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Add tab navigation to main app and embed a new 911 Location tab
- Implement `text911.html` to show GPS coordinates, address, plus code, and texting availability
- Check local coordinates against `911-texting.json` to hide the Text 911 option where unsupported

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ade85adbbc8332837b15747cf4576e