### PR TITLE
feat: add vault tab and app skeleton

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,18 +7,31 @@ class UnifiedHealthApp extends EmergencyQRApp {
     super();
     this.vaultUnlocked = false;
     this.attachments = new Map();
-    this.phvData = {};
+    this.phvData = { sections: {}, attachments: [] };
   }
 
   async createAttachment(data, type) {
     // Placeholder for attachment creation and upload.
     const guid = self.crypto.randomUUID();
     this.attachments.set(guid, { data, type });
+    this.phvData.attachments.push({ guid, type });
     return guid;
+  }
+
+  exportVault() {
+    return this.phvData;
+  }
+
+  importVault(vaultData) {
+    if (!vaultData) return;
+    this.phvData = vaultData;
   }
 
   async loadVault(password) {
     // Placeholder for password verification and vault loading.
+    if (window.currentBlob && window.currentBlob.vault) {
+      this.importVault(window.currentBlob.vault);
+    }
     this.vaultUnlocked = true;
     return true;
   }

--- a/index.html
+++ b/index.html
@@ -1989,7 +1989,12 @@
                     encryptedWith: await sha256Hash(currentKey + password)
                 } : null;
 
-                const payload = { publicInfo, privateInfo, passwordHint: formData.passwordHint };
+                const payload = {
+                    publicInfo,
+                    privateInfo,
+                    passwordHint: formData.passwordHint,
+                    vault: window.healthApp.exportVault()
+                };
                 const encryptedData = await encrypt(JSON.stringify(payload), currentKey);
 
                 // Create data package
@@ -2048,7 +2053,15 @@
 
                 window.currentQRUrl = qrUrl;
 
-                currentBlob = { version: 'v2', created, name: formData.name, criticalInfo: formData.criticalInfo, publicInfo, privateInfo };
+                currentBlob = {
+                    version: 'v2',
+                    created,
+                    name: formData.name,
+                    criticalInfo: formData.criticalInfo,
+                    publicInfo,
+                    privateInfo,
+                    vault: window.healthApp.exportVault()
+                };
 
                 // Show success
                 document.getElementById('create-form').style.display = 'none';


### PR DESCRIPTION
## Summary
- add placeholder Vault tab with iframe to load Personal Health Vault module
- wire up showVaultTab handler and include basic styles
- scaffold UnifiedHealthApp class for future vault integration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adf1db204c83329be9eaca1b8ee9dc