### PR TITLE
Include GUID in health record save requests

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -1477,6 +1477,11 @@
                 this.lastActivityTime = Date.now();
                 this.lockTimeout = null;
                 this.timerInterval = null;
+
+                // Record identifier
+                this.guid = (window.parent && window.parent.currentGUID)
+                    ? window.parent.currentGUID
+                    : window.crypto.randomUUID();
                 
                 // Dynamic data structure
                 this.dynamicData = {
@@ -1998,6 +2003,7 @@
                 try {
                     const encrypted = await this.crypto.encrypt(formData, password);
                     const fileContent = JSON.stringify({
+                        guid: this.guid,
                         encrypted: true,
                         version: '3.0',
                         data: encrypted
@@ -2081,8 +2087,14 @@
             
             async processFileData(fileData, password) {
                 try {
+                    if (fileData.guid) {
+                        this.guid = fileData.guid;
+                    }
                     const decrypted = await this.crypto.decrypt(fileData.data, password);
-                    
+                    if (decrypted.guid) {
+                        this.guid = decrypted.guid;
+                    }
+
                     this.loadFormData(decrypted);
                     
                     // Update UI
@@ -2141,6 +2153,8 @@
                 document.querySelectorAll('.section').forEach(section => {
                     formData.collapsedSections[section.id] = section.classList.contains('collapsed');
                 });
+
+                formData.guid = this.guid;
 
                 return formData;
             }


### PR DESCRIPTION
## Summary
- Attach a GUID to health record saves
- Persist GUID through form data and file loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae06e55d2c833299503f7e0306ba80