### PR TITLE
feat: add modal editing and modernize dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,17 @@
             box-sizing: border-box;
         }
 
+        :root {
+            --primary: #4F46E5;
+            --danger: #EF4444;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --surface: #FFFFFF;
+            --surface-alt: #F9FAFB;
+            --text: #111827;
+            --text-secondary: #6B7280;
+        }
+
         html, body {
             margin: 0 !important;
             padding: 0 !important;
@@ -23,7 +34,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+            background: var(--surface-alt);
             min-height: 100vh !important;
             display: flex !important;
             flex-direction: column;
@@ -72,7 +83,7 @@
         }
         
         .header {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--primary);
             color: white;
             padding: 20px;
             text-align: center;
@@ -155,7 +166,7 @@
         }
         
         .phone-link {
-            color: #667eea;
+            color: var(--primary);
             text-decoration: none;
             font-weight: 600;
             display: inline-flex;
@@ -167,9 +178,9 @@
             border-radius: 8px;
             transition: all 0.3s;
         }
-        
+
         .phone-link:hover {
-            background: #667eea;
+            background: var(--primary);
             color: white;
             transform: translateY(-2px);
         }
@@ -261,7 +272,7 @@
         .btn {
             width: 100%;
             padding: 12px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--primary);
             color: white;
             border: none;
             border-radius: 10px;
@@ -277,7 +288,7 @@
         
         .btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 10px 25px rgba(102, 126, 234, 0.3);
+            box-shadow: 0 10px 25px rgba(79, 70, 229, 0.3);
         }
         
         .btn:disabled {
@@ -293,13 +304,13 @@
         
         .btn-outline {
             background: white;
-            color: #667eea;
-            border: 2px solid #667eea;
+            color: var(--primary);
+            border: 2px solid var(--primary);
             margin-top: 10px;
         }
         
         .btn-outline:hover {
-            background: #667eea;
+            background: var(--primary);
             color: white;
         }
         
@@ -996,17 +1007,71 @@
         }
         .mini-progress .progress-bar {
             height: 100%;
-            background: #667eea;
+            background: var(--primary);
             border-radius: 2px;
         }
         .field-row {
             display: flex;
             justify-content: space-between;
-            padding: 4px 0;
+            padding: 12px 0;
             font-size: 0.875rem;
+            border-bottom: 1px solid var(--surface-alt);
         }
-        .field-row.missing .field-value {
-            color: #667eea;
+        .field-row.missing {
+            opacity: 0.6;
+        }
+        .add-button {
+            color: var(--primary);
+            cursor: pointer;
+            font-weight: 500;
+        }
+        .add-button:hover {
+            text-decoration: underline;
+        }
+
+        .field-modal {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+        }
+        .field-modal.active { display: flex; }
+        .modal-backdrop {
+            position: absolute;
+            inset: 0;
+            background: rgba(0,0,0,0.5);
+        }
+        .modal-content {
+            position: relative;
+            background: var(--surface);
+            padding: 20px;
+            border-radius: 12px;
+            z-index: 1;
+            max-width: 400px;
+            width: calc(100% - 40px);
+        }
+        .modal-actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            margin-top: 15px;
+        }
+        .btn-primary {
+            background: var(--primary);
+            color: #fff;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 8px;
+            cursor: pointer;
+        }
+        .btn-ghost {
+            background: transparent;
+            border: 1px solid var(--primary);
+            color: var(--primary);
+            padding: 8px 16px;
+            border-radius: 8px;
+            cursor: pointer;
         }
         .quick-actions {
             margin-top: 20px;
@@ -2110,17 +2175,17 @@
                         ${renderSectionCard('Emergency', '🚨', sections.emergency, [
                             { label: 'Blood Type', value: fields.emergency.bloodType },
                             { label: 'Allergies', value: fields.emergency.allergies },
-                            { label: 'Medications', value: fields.emergency.medications, missing: true }
+                            { label: 'Medications', value: fields.emergency.medications, missing: true, section: 'emergency', field: 'medications' }
                         ])}
 
                         ${renderSectionCard('Contacts', '📞', sections.contacts, [
                             { label: 'Primary', value: fields.contacts.primary?.name },
-                            { label: 'Secondary', value: fields.contacts.secondary?.name, missing: true }
+                            { label: 'Secondary', value: fields.contacts.secondary?.name, missing: true, section: 'contacts', field: 'secondary' }
                         ])}
 
                         ${renderSectionCard('Private', '🔒', sections.private, [
                             { label: 'SSN', value: fields.private.ssn, masked: true },
-                            { label: 'Insurance', value: fields.private.insurance, missing: true },
+                            { label: 'Insurance', value: fields.private.insurance, missing: true, section: 'private', field: 'insurance' },
                             { label: 'Notes', value: fields.private.medicalNotes }
                         ])}
 
@@ -2162,15 +2227,67 @@
                             <div class="field-row ${f.missing ? 'missing' : ''}">
                                 <span class="field-label">${f.label}</span>
                                 <span class="field-value">
-                                    ${f.missing ? '➕ Add' :
-                                      f.masked ? '••••' :
-                                      f.value || '—'}
+                                    ${f.missing ? `<span class="add-button" onclick="addFieldModal('${f.section}','${f.field}')">+ Add</span>` :
+                                      (f.masked ? '••••' : (f.value || '—'))}
                                 </span>
                             </div>
                         `).join('')}
                     </div>
                 </div>
             `;
+        }
+
+        function addFieldModal(section, field) {
+            const modal = document.createElement('div');
+            modal.className = 'field-modal active';
+            modal.innerHTML = `
+                <div class="modal-backdrop" onclick="closeModal()"></div>
+                <div class="modal-content">
+                    <h3>Add ${field}</h3>
+                    ${getFieldInput(section, field)}
+                    <div class="modal-actions">
+                        <button onclick="saveField('${section}', '${field}')" class="btn-primary">Save</button>
+                        <button onclick="closeModal()" class="btn-ghost">Cancel</button>
+                    </div>
+                </div>
+            `;
+            document.body.appendChild(modal);
+        }
+
+        function getFieldInput(section, field) {
+            const configs = {
+                'emergency.medications': '<textarea id="field-input" placeholder="List current medications, dosages, and frequency"></textarea>',
+                'emergency.bloodType': '<select id="field-input"><option>A+</option><option>A-</option><option>B+</option><option>B-</option><option>AB+</option><option>AB-</option><option>O+</option><option>O-</option></select>',
+                'contacts.secondary': '<input id="field-input" type="text" placeholder="Name"><input id="field-input2" type="tel" placeholder="Phone">',
+                'private.insurance': '<input id="field-input" type="text" placeholder="Provider"><input id="field-input2" type="text" placeholder="Policy #">'
+            };
+            return configs[`${section}.${field}`] || '<input id="field-input" type="text">';
+        }
+
+        function closeModal() {
+            const modal = document.querySelector('.field-modal');
+            if (modal) modal.remove();
+        }
+
+        function saveField(section, field) {
+            const input = document.querySelector('.field-modal #field-input');
+            const input2 = document.querySelector('.field-modal #field-input2');
+            const value = input ? input.value.trim() : '';
+            const value2 = input2 ? input2.value.trim() : '';
+
+            if (!currentBlob) currentBlob = {};
+            if (section === 'emergency') {
+                currentBlob.publicInfo = currentBlob.publicInfo || {};
+                currentBlob.publicInfo[field] = value;
+            } else if (section === 'contacts' && field === 'secondary') {
+                currentBlob.publicInfo = currentBlob.publicInfo || {};
+                currentBlob.publicInfo.secondaryContact = { name: value, phone: value2 };
+            } else if (section === 'private') {
+                currentBlob.privateInfo = currentBlob.privateInfo || {};
+                currentBlob.privateInfo[field] = value2 ? { provider: value, policy: value2 } : value;
+            }
+            closeModal();
+            showOwnerDashboard();
         }
 
         async function showUpdateForm(password) {


### PR DESCRIPTION
## Summary
- modernize color palette with CSS variables and flat header
- add modal-based field editing for missing dashboard fields
- style field rows and add-button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae0d1dbc9c8332882d56db1d49b908