### PR TITLE
Add dashboard navigation and breadcrumbs

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -172,7 +172,18 @@
             background: #dc2626;
             color: white;
         }
-        
+
+        .breadcrumbs {
+            margin: 10px 20px;
+            font-size: 0.875rem;
+            color: #64748b;
+        }
+
+        .breadcrumbs a {
+            color: #3b82f6;
+            text-decoration: none;
+        }
+
         .nav-tabs {
             position: fixed;
             top: 56px;
@@ -926,6 +937,11 @@
         <div class="tab" data-section="emergency-plans">🆘 Emergency Plans</div>
     </div>
 
+    <nav class="breadcrumbs no-print">
+        <a href="index.html" onclick="goBackOrDashboard(event)">Dashboard</a> /
+        <span>Health Records</span>
+    </nav>
+
     <!-- Password Modal -->
     <div class="modal" id="passwordModal">
         <div class="modal-content">
@@ -1476,6 +1492,14 @@
 
     <script src="session.js"></script>
     <script>
+        function goBackOrDashboard(e) {
+            if (document.referrer !== '' && history.length > 1) {
+                history.back();
+            } else {
+                window.location.href = 'index.html';
+            }
+            if (e) e.preventDefault();
+        }
         // Application class to manage state and functionality
         class HealthVaultApp {
             constructor() {

--- a/modules.html
+++ b/modules.html
@@ -45,6 +45,17 @@
             text-decoration: none;
             font-size: 14px;
         }
+
+        .breadcrumbs {
+            margin: 10px 20px;
+            font-size: 14px;
+            color: #666;
+        }
+
+        .breadcrumbs a {
+            color: #667eea;
+            text-decoration: none;
+        }
         
         h1 {
             font-size: 24px;
@@ -329,11 +340,17 @@
     <div class="container">
         <header>
             <div class="header-nav">
-                <a href="#" class="back-link">← Back to Profile</a>
+                <a href="index.html" class="back-link" onclick="goBackOrDashboard(event)">← Dashboard</a>
             </div>
             <h1>Settings <span class="save-indicator" id="saveIndicator">Saved</span></h1>
         </header>
-        
+
+        <nav class="breadcrumbs">
+            <a href="index.html" onclick="goBackOrDashboard(event)">Dashboard</a> /
+            <span>Settings</span> /
+            <span>Modules</span>
+        </nav>
+
         <div class="tabs">
             <a href="#" class="tab active">Modules</a>
             <a href="#" class="tab">Security</a>
@@ -611,6 +628,15 @@
 
         // Initialize
         renderModules();
+
+        function goBackOrDashboard(e) {
+            if (document.referrer !== '' && history.length > 1) {
+                history.back();
+            } else {
+                window.location.href = 'index.html';
+            }
+            if (e) e.preventDefault();
+        }
     </script>
 </body>
 </html>

--- a/text911.html
+++ b/text911.html
@@ -37,6 +37,15 @@
             font-size: 0.8125rem;
             opacity: 0.95;
         }
+        .breadcrumbs {
+            font-size: 0.875rem;
+            color: #4b5563;
+            padding: 10px 20px;
+        }
+        .breadcrumbs a {
+            color: #991b1b;
+            text-decoration: none;
+        }
         .emergency-buttons {
             display: grid;
             grid-template-columns: 1fr 1fr;
@@ -265,6 +274,10 @@
 </head>
 <body>
     <div class="container">
+        <nav class="breadcrumbs">
+            <a href="index.html" onclick="goBackOrDashboard(event)">Dashboard</a> /
+            <span>Emergency 911</span>
+        </nav>
         <div class="emergency-buttons" id="emergencyButtons" style="display:none;">
             <a href="tel:911" class="btn-911 btn-call">
                 <span class="icon">📞</span>
@@ -314,6 +327,14 @@
     </div>
     <div id="toast" class="toast"></div>
     <script>
+        function goBackOrDashboard(e){
+            if (document.referrer !== '' && history.length > 1){
+                history.back();
+            } else {
+                window.location.href='index.html';
+            }
+            if(e) e.preventDefault();
+        }
         let currentLocation=null;
         const CODE_ALPHABET='23456789CFGHJMPQRVWX';
         const STATE_ABBREVIATIONS={


### PR DESCRIPTION
## Summary
- Add dashboard link to settings page and show path breadcrumbs
- Introduce breadcrumbs and dashboard navigation to health records
- Include breadcrumbs and back-aware dashboard link on emergency 911 view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae13118f088332ba93ff11d50654ae