### PR TITLE
Fix dashboard button navigation

### DIFF
--- a/modules.html
+++ b/modules.html
@@ -329,7 +329,7 @@
     <div class="container">
         <header>
             <div class="header-nav">
-                <a href="#" class="back-link">← Back to Profile</a>
+                <a href="index.html" class="back-link">← Dashboard</a>
             </div>
             <h1>Settings <span class="save-indicator" id="saveIndicator">Saved</span></h1>
         </header>


### PR DESCRIPTION
## Summary
- Link the dashboard button in the modules settings page to the app's main page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae19912a7c8332b5419ac8a7b2dea0