### PR TITLE
Ensure EHR tabs stay pinned for navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3213,14 +3213,13 @@
                 document.getElementById('qrTab').style.display = 'none';
                 document.getElementById('text911Tab').style.display = 'none';
                 const frame = document.getElementById('healthRecordsFrame');
-                frame.onload = () => {
-                    frame.style.height = frame.contentDocument.body.scrollHeight + 'px';
+                const setFrameHeight = () => {
+                    frame.style.height = window.innerHeight + 'px';
                 };
+                setFrameHeight();
+                window.addEventListener('resize', setFrameHeight);
                 if (!frame.src) {
                     frame.src = 'health-records.html';
-                } else {
-                    // Ensure height is adjusted if the frame was already loaded
-                    frame.style.height = frame.contentDocument.body.scrollHeight + 'px';
                 }
                 document.getElementById('healthRecordsTab').style.display = 'block';
             } catch (e) {
@@ -3301,7 +3300,7 @@
     </script>
     </div>
     <div id="healthRecordsTab" style="display:none;">
-        <iframe id="healthRecordsFrame" style="border:none;width:100%;"></iframe>
+        <iframe id="healthRecordsFrame" style="border:none;width:100%;height:100vh;"></iframe>
     </div>
     <div id="text911Tab" style="display:none;">
         <div class="container">


### PR DESCRIPTION
## Summary
- Set EHR iframe to viewport height and enable resizing so its content scrolls internally
- Removed auto-expanding iframe height to keep navigation tabs fixed at the top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae19beb7608332abd7ad8866a30d25