### PR TITLE
Use main password for health records access

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -1512,13 +1512,27 @@
                 this.setupSectionToggles();
                 this.trackActivity();
 
-                // Start in a locked state and prompt for password
+                // Use password from main app if available
+                this.sessionPassword = (window.parent && window.parent.ownerPassword) ||
+                    sessionStorage.getItem('ownerPassword');
+
+                // Start in a locked state but auto-unlock if password exists
                 this.lockFile();
-                if (this.isFirstTime) {
-                    document.getElementById('firstTimeModal').classList.add('active');
-                    localStorage.setItem('phvFirstTime', 'false');
+                if (this.sessionPassword) {
+                    if (this.isFirstTime) {
+                        document.getElementById('firstTimeModal').classList.add('active');
+                        localStorage.setItem('phvFirstTime', 'false');
+                    }
+                    document.getElementById('lockBtn').style.display = 'inline-block';
+                    document.getElementById('changePasswordBtn').style.display = 'inline-block';
+                    this.completeUnlock();
                 } else {
-                    this.showPasswordModal('Set Password for Encryption', true, 'unlock');
+                    if (this.isFirstTime) {
+                        document.getElementById('firstTimeModal').classList.add('active');
+                        localStorage.setItem('phvFirstTime', 'false');
+                    } else {
+                        this.showPasswordModal('Set Password for Encryption', true, 'unlock');
+                    }
                 }
 
                 // Update save status
@@ -1554,7 +1568,9 @@
                 document.getElementById('modalCancel').addEventListener('click', () => this.closeModal());
                 document.getElementById('firstTimeClose').addEventListener('click', () => {
                     document.getElementById('firstTimeModal').classList.remove('active');
-                    this.showPasswordModal('Set Password for Encryption', true, 'unlock');
+                    if (!this.sessionPassword) {
+                        this.showPasswordModal('Set Password for Encryption', true, 'unlock');
+                    }
                 });
                 
                 // Password field events

--- a/index.html
+++ b/index.html
@@ -2072,6 +2072,7 @@
             const verified = await verifyOwnerPassword(password);
             if (verified) {
                 ownerPassword = password;
+                sessionStorage.setItem('ownerPassword', ownerPassword);
                 document.querySelector('.login-btn').style.display = 'none';
                 document.querySelector('.dashboard-btn').style.display = 'inline-block';
                 document.querySelector('.logout-btn').style.display = 'inline-block';
@@ -2083,6 +2084,7 @@
 
         function logoutOwner() {
             ownerPassword = null;
+            sessionStorage.removeItem('ownerPassword');
 
             document.querySelector('.dashboard-btn').style.display = 'none';
             document.querySelector('.health-records-btn').style.display = 'none';
@@ -3231,21 +3233,12 @@
          }
 
         async function showHealthRecordsTab() {
-            let password = ownerPassword;
-            if (!password) {
-                password = prompt('Enter health records password');
-                if (!password) return;
-                try {
-                    await window.healthApp.loadVault(password);
-                    ownerPassword = password;
-                    showOwnerDashboard();
-                } catch (e) {
-                    alert('Unable to unlock health records');
-                }
-                return;
+            if (!ownerPassword) {
+                await ownerLogin();
+                if (!ownerPassword) return;
             }
             try {
-                await window.healthApp.loadVault(password);
+                await window.healthApp.loadVault(ownerPassword);
                 document.getElementById('qrTab').style.display = 'none';
                 document.getElementById('text911Tab').style.display = 'none';
                 const frame = document.getElementById('healthRecordsFrame');


### PR DESCRIPTION
## Summary
- Store owner password in session storage for reuse
- Auto-open health records using existing login
- Health vault page uses parent password and skips redundant prompt

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1acb1d388332ac568ec8977880ca