### PR TITLE
Move 911 widget under iKey logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,10 +81,6 @@
             }
 
             .center-911 {
-                order: 2;
-                flex-basis: 100%;
-                display: flex;
-                justify-content: flex-start;
                 margin-top: 4px;
             }
 
@@ -828,14 +824,20 @@
             top: 0;
             left: 0;
             right: 0;
-            height: 48px;
             background: white;
             display: grid;
-            grid-template-columns: 1fr auto 1fr;
+            grid-template-columns: auto 1fr;
             align-items: center;
-            padding: 0 10px;
+            padding: 4px 10px;
             box-shadow: 0 2px 6px rgba(0,0,0,0.1);
             z-index: 1000;
+        }
+
+        .logo-container {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-self: start;
         }
 
         .logo {
@@ -843,7 +845,6 @@
             display: flex;
             align-items: center;
             gap: 6px;
-            justify-self: start;
         }
 
          .logo-text-short {
@@ -851,7 +852,7 @@
          }
 
          .center-911 {
-             justify-self: center;
+            margin-top: 4px;
          }
 
          .emergency-911-btn {
@@ -1361,11 +1362,13 @@
 </head>
 <body>
     <div class="top-bar">
-        <div class="logo">🔑 <span class="logo-text-full">iKey</span><span class="logo-text-short">iKey</span></div>
-        <div class="center-911">
-            <button class="emergency-911-btn" onclick="show911Tab()">
-                <span>📍 911</span>
-            </button>
+        <div class="logo-container">
+            <div class="logo">🔑 <span class="logo-text-full">iKey</span><span class="logo-text-short">iKey</span></div>
+            <div class="center-911">
+                <button class="emergency-911-btn" onclick="show911Tab()">
+                    <span>📍 911</span>
+                </button>
+            </div>
         </div>
         <div class="controls">
             <div class="size-controls">


### PR DESCRIPTION
## Summary
- Display 911 button below the iKey logo instead of the main navigation bar
- Adjust top bar layout and styles to accommodate the new button placement

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1b6546088332aecd0a0d9f17369c