### PR TITLE
Adjust nav tabs offset to clear security bar

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -3243,6 +3243,18 @@
             };
         }
         
+        // Adjust nav tabs position based on the security bar height
+        function adjustNavTabsPosition() {
+            const securityBar = document.querySelector('.security-bar');
+            const navTabs = document.getElementById('navTabs');
+            if (securityBar && navTabs) {
+                navTabs.style.top = securityBar.offsetHeight + 'px';
+            }
+        }
+
+        window.addEventListener('load', adjustNavTabsPosition);
+        window.addEventListener('resize', adjustNavTabsPosition);
+
         // Initialize the application
         const app = new HealthVaultApp();
     </script>


### PR DESCRIPTION
## Summary
- Dynamically position nav tabs below the security bar to keep section labels fully visible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1d3ba2ac8332ba2bb98d0308996d