### PR TITLE
refactor: move 911 access out of header

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -72,15 +72,26 @@
             background: #f0f2f5;
             border-radius: 12px;
         }
-        
-        .btn-911 {
+
+        .access-911 {
             background: #ef4444;
             color: white;
             border: none;
-            padding: 6px 14px;
-            border-radius: 20px;
-            font-weight: bold;
+            padding: 10px 16px;
+            border-radius: 8px;
             cursor: pointer;
+        }
+
+        .access-911:active {
+            opacity: 0.9;
+        }
+
+        .emergency-card {
+            padding: 16px;
+            background: #fff5f5;
+            border: 2px dashed #ef4444;
+            border-radius: 12px;
+            margin-bottom: 20px;
         }
         
         /* Main Container */
@@ -351,7 +362,6 @@
             </div>
             <div class="nav-right">
                 <span class="session-timer">42m remaining</span>
-                <button class="btn-911">📍 911</button>
                 <button class="btn btn-secondary">Share Profile</button>
             </div>
         </nav>
@@ -459,6 +469,13 @@
 
             <!-- Side Panel -->
             <div>
+                <!-- Emergency Access -->
+                <div class="card emergency-card">
+                    <h3 class="card-title">🚨 Emergency Services</h3>
+                    <p style="margin-bottom:12px;">Double-click to open</p>
+                    <button class="access-911" ondblclick="confirmEmergencyAccess()" title="Double-click to activate">Access Emergency Services</button>
+                </div>
+
                 <!-- Quick Access -->
                 <div class="card">
                     <h3 class="card-title">⚡ Quick Access</h3>
@@ -495,5 +512,12 @@
             </div>
         </div>
     </div>
+    <script>
+    function confirmEmergencyAccess() {
+        if (confirm('Open Emergency Services?')) {
+            window.location.href = 'text911.html';
+        }
+    }
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -79,11 +79,6 @@
                 height: auto;
                 padding: 4px 10px;
             }
-
-            .center-911 {
-                margin-top: 4px;
-            }
-
             .logo-text-full {
                 display: none;
             }
@@ -851,27 +846,6 @@
              display: none;
          }
 
-         .center-911 {
-            margin-top: 4px;
-         }
-
-         .emergency-911-btn {
-             background: #ff4757;
-             color: white;
-             border: none;
-             border-radius: 20px;
-             padding: 6px 16px;
-             font-weight: bold;
-             cursor: pointer;
-             font-size: 0.875rem;
-             transition: all 0.3s;
-         }
-
-         .emergency-911-btn:hover {
-             background: #ff6b7a;
-             transform: scale(1.05);
-         }
-
         .controls {
             display: flex;
             align-items: center;
@@ -1420,17 +1394,37 @@
         .allergy-warnings .medium {
             color: #d69e2e;
         }
+
+        .emergency-card {
+            margin: 16px;
+            padding: 16px;
+            background: #fff5f5;
+            border: 2px dashed var(--danger);
+            border-radius: 12px;
+        }
+
+        .emergency-card h3 {
+            margin-bottom: 8px;
+        }
+
+        .access-911 {
+            background: var(--danger);
+            color: white;
+            border: none;
+            padding: 10px 16px;
+            border-radius: 8px;
+            cursor: pointer;
+        }
+
+        .access-911:active {
+            opacity: 0.9;
+        }
     </style>
 </head>
 <body>
     <div class="top-bar">
         <div class="logo-container">
             <div class="logo">🔑 <span class="logo-text-full">iKey</span><span class="logo-text-short">iKey</span></div>
-            <div class="center-911">
-                <button class="emergency-911-btn" onclick="show911Tab()">
-                    <span>📍 911</span>
-                </button>
-            </div>
         </div>
         <div class="controls">
             <div class="size-controls">
@@ -2337,6 +2331,13 @@
                         ${renderSectionCard('Electronic Health Records', '🏥', sections.vault, [
                             { label: 'Records', value: fields.vault.records + ' documents' }
                         ], 'showHealthRecordsTab()')}
+                        <div class="emergency-card">
+                            <h3>🚨 Emergency Services</h3>
+                            <p style="margin-bottom:8px;">Double-click to open</p>
+                            <button class="access-911" ondblclick="confirmEmergencyAccess()" title="Double-click to activate">
+                                Access Emergency Services
+                            </button>
+                        </div>
                     </div>
 
                     <div class="quick-actions">
@@ -3422,7 +3423,13 @@
              }
          }
 
-        async function showHealthRecordsTab() {
+        function confirmEmergencyAccess() {
+            if (confirm('Open Emergency Services?')) {
+                show911Tab();
+            }
+        }
+
+       async function showHealthRecordsTab() {
             if (!ownerPassword) {
                 await ownerLogin();
                 if (!ownerPassword) return;


### PR DESCRIPTION
## Summary
- remove emergency 911 button from header
- add deliberate double-click emergency card on dashboard
- provide simple confirm logic for accessing emergency services

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1fc58c1c8332b7b123b20350f3a9