### PR TITLE
Format last updated timestamps with local time

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -2949,7 +2949,7 @@
                     <div class="pdf-header">
                         <h1>Personal Health Record</h1>
                         <p>Generated: ${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()}</p>
-                        <p>Last Updated: ${data.lastUpdated || 'Never'}</p>
+                        <p>Last Updated: ${data.lastUpdated ? new Date(data.lastUpdated).toLocaleString() : 'Never'}</p>
                     </div>
                 `;
                 

--- a/modules.html
+++ b/modules.html
@@ -498,7 +498,7 @@
             // Default configuration
             const defaultConfig = {
                 version: "1.0",
-                lastUpdated: new Date().toISOString(),
+                lastUpdated: new Date().toLocaleString(),
                 modules: {}
             };
             
@@ -506,7 +506,7 @@
                 defaultConfig.modules[module.id] = {
                     enabled: module.defaultEnabled,
                     settings: {},
-                    addedDate: new Date().toISOString()
+                    addedDate: new Date().toLocaleString()
                 };
             });
             
@@ -556,12 +556,12 @@
             if (!moduleConfig.modules[moduleId]) {
                 moduleConfig.modules[moduleId] = {
                     settings: {},
-                    addedDate: new Date().toISOString()
+                    addedDate: new Date().toLocaleString()
                 };
             }
-            
+
             moduleConfig.modules[moduleId].enabled = enabled;
-            moduleConfig.lastUpdated = new Date().toISOString();
+            moduleConfig.lastUpdated = new Date().toLocaleString();
             
             // Update UI
             const card = document.querySelector(`[data-module="${moduleId}"]`).closest('.module-card');


### PR DESCRIPTION
## Summary
- show local time for module config updates
- display health record PDF last updated in local time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae20b928508332a3c5848d1238c82c