### PR TITLE
Fix dashboard visibility when switching from EHR

### DIFF
--- a/index.html
+++ b/index.html
@@ -2308,6 +2308,11 @@
         }
 
         function showOwnerDashboard() {
+            // Ensure the dashboard content is visible regardless of the current tab
+            document.getElementById('qrTab').style.display = 'block';
+            document.getElementById('text911Tab').style.display = 'none';
+            document.getElementById('healthRecordsTab').style.display = 'none';
+
             currentMode = 'dashboard';
             const container = document.getElementById('main-content');
 


### PR DESCRIPTION
## Summary
- ensure `showOwnerDashboard` switches to the QR tab so the dashboard is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae244c0764833288c86dd49f248597