### PR TITLE
Add autosave status indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -2415,7 +2415,7 @@
                         <div class="profile-summary">
                             <h2>${fields.basic.name || 'Your iKey'}</h2>
                             <p class="security-status">Security Level: <span class="level-${securityLevel.toLowerCase()}">${securityLevel}</span></p>
-                            <p class="last-updated">Last updated: ${currentBlob.metadata?.updated || 'Never'}</p>
+                            <p class="last-updated">Last updated: <span id="last-updated-time">${currentBlob.metadata?.updated || 'Never'}</span> <span id="autosave-status"></span></p>
                         </div>
                     </div>
 

--- a/session.js
+++ b/session.js
@@ -195,12 +195,22 @@ class SessionManager {
     }
 
     autoSave() {
+        const status = document.getElementById('autosave-status');
+        if (status) status.textContent = 'Saving...';
+
         const draft = {};
         document.querySelectorAll('input, textarea').forEach(el => {
             draft[el.id || el.name] = el.value;
         });
         localStorage.setItem('sessionDraft', JSON.stringify(draft));
         this.saveToArchive(draft);
+
+        if (status) {
+            status.textContent = 'Saved';
+            setTimeout(() => { status.textContent = ''; }, 2000);
+        }
+        const updated = document.getElementById('last-updated-time');
+        if (updated) updated.textContent = new Date().toLocaleString();
     }
 
     saveToArchive(data) {


### PR DESCRIPTION
## Summary
- display last updated time and autosave status on dashboard
- show saving and saved messages during autosave

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae2642580c8332ad23f9d185f3d551