### PR TITLE
Preserve GUID when saving health records

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -1495,9 +1495,13 @@
                 this.loaded = false;
 
                 // Record identifier
+                // Prefer existing GUID from parent window, localStorage or URL
+                const urlParams = new URLSearchParams(window.location.search);
                 this.guid = (window.parent && window.parent.currentGUID)
-                    ? window.parent.currentGUID
-                    : window.crypto.randomUUID();
+                    || localStorage.getItem('ikey_current_guid')
+                    || urlParams.get('guid')
+                    || window.location.hash.slice(1)
+                    || window.crypto.randomUUID();
                 
                 // Dynamic data structure
                 this.dynamicData = {


### PR DESCRIPTION
## Summary
- Ensure health records page uses existing iKey GUID from parent, localStorage, or URL
- Fall back to new GUID only when no identifier is available

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae26e4d7908332b5090528e3e69703