### PR TITLE
feat: add global text size controls

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -350,6 +350,7 @@
             }
         }
     </style>
+    <script src="text-size.js"></script>
 </head>
 <body>
     <header class="header">

--- a/emergency-profile-2.html
+++ b/emergency-profile-2.html
@@ -366,6 +366,7 @@
             }
         }
     </style>
+    <script src="text-size.js"></script>
 </head>
 <body>
     <div class="container">

--- a/health-records.html
+++ b/health-records.html
@@ -106,6 +106,20 @@
             flex-grow: 0;
             flex-shrink: 0;
         }
+
+        .size-controls {
+            display: flex;
+            gap: 4px;
+        }
+
+        .size-toggle {
+            background: white;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 6px 10px;
+            cursor: pointer;
+            font-size: 0.75rem;
+        }
         
         .btn {
             padding: 5px 12px;
@@ -889,6 +903,7 @@
             display: flex;
         }
     </style>
+    <script src="text-size.js"></script>
 </head>
 <body>
     <div class="security-bar no-print">
@@ -906,6 +921,10 @@
             <button class="btn btn-secondary" id="exportBtn">Export/Print</button>
             <button class="btn btn-secondary" id="changePasswordBtn" style="display: none;">Change Password</button>
             <button class="btn btn-save" id="saveBtn">Save to Archive.org</button>
+            <div class="size-controls">
+                <button class="size-toggle" onclick="changeTextSize(-1)">🔍-</button>
+                <button class="size-toggle" onclick="changeTextSize(1)">🔍+</button>
+            </div>
             <div id="session-timer" class="session-timer">
                 <span id="session-countdown"></span>
             </div>

--- a/index.html
+++ b/index.html
@@ -1562,6 +1562,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js"></script>
     <script src="app.js"></script>
     <script src="medication.js"></script>
+    <script src="text-size.js"></script>
 
     <script>
         // Configuration
@@ -1664,21 +1665,6 @@
           document.querySelectorAll('.lang-option').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.lang === langCode);
           });
-        }
-
-        function applyTextSize(size) {
-          const sizes = { standard: '16px', large: '20px', xlarge: '24px' };
-          const next = sizes[size] || sizes.standard;
-          document.documentElement.style.fontSize = next;
-        }
-
-        function changeTextSize(delta) {
-          const order = ['standard', 'large', 'xlarge'];
-          const current = localStorage.getItem('ikey_text_size') || 'standard';
-          const nextIndex = Math.min(Math.max(order.indexOf(current) + delta, 0), order.length - 1);
-          const next = order[nextIndex];
-          localStorage.setItem('ikey_text_size', next);
-          applyTextSize(next);
         }
 
         function toggleLangDropdown(force) {
@@ -1861,9 +1847,6 @@
                 navigator.language.substring(0, 2) ||
                 'en';
             setLanguage(savedLang);
-
-            const savedSize = localStorage.getItem('ikey_text_size') || 'standard';
-            applyTextSize(savedSize);
 
             await parseAndDisplay();
 

--- a/modules.html
+++ b/modules.html
@@ -324,6 +324,7 @@
             }
         }
     </style>
+    <script src="text-size.js"></script>
 </head>
 <body>
     <div class="container">

--- a/text-size.js
+++ b/text-size.js
@@ -1,0 +1,19 @@
+(function(){
+  const sizes = { standard: '16px', large: '20px', xlarge: '24px', xxlarge: '32px' };
+  const order = Object.keys(sizes);
+
+  window.applyTextSize = function(size) {
+    document.documentElement.style.fontSize = sizes[size] || sizes.standard;
+  };
+
+  window.changeTextSize = function(delta) {
+    const current = localStorage.getItem('ikey_text_size') || 'standard';
+    const nextIndex = Math.min(Math.max(order.indexOf(current) + delta, 0), order.length - 1);
+    const next = order[nextIndex];
+    localStorage.setItem('ikey_text_size', next);
+    applyTextSize(next);
+  };
+
+  const savedSize = localStorage.getItem('ikey_text_size') || 'standard';
+  applyTextSize(savedSize);
+})();

--- a/text911.html
+++ b/text911.html
@@ -262,6 +262,7 @@
             body{padding:0;}
         }
     </style>
+    <script src="text-size.js"></script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
- extract text size logic into new shared script and support an extra xxlarge size
- wire text size script into every page and add controls to the EHR view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae271bf2188332a1f2b6d4afc3a066