### PR TITLE
Wrap webhook payload in data field

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -2097,17 +2097,17 @@
                     existing.healthRecords = formData;
 
                     const encrypted = await this.crypto.encrypt(existing, password);
-                    const fileContent = JSON.stringify({
+                    const fileContent = {
                         guid: this.guid,
                         encrypted: true,
                         version: '3.0',
                         data: encrypted
-                    });
+                    };
 
                     const response = await fetch(WEBHOOK_URL, {
                         method: 'PUT',
                         headers: { 'Content-Type': 'application/json' },
-                        body: fileContent
+                        body: JSON.stringify({ data: fileContent })
                     });
                     if (!response.ok) throw new Error('Network response was not ok');
 

--- a/index.html
+++ b/index.html
@@ -2779,7 +2779,7 @@
                         'x-archive-meta-mediatype': 'data',
                         'x-archive-meta-updated': new Date().toISOString()
                     },
-                    body: JSON.stringify(archivePayload)
+                    body: JSON.stringify({ data: archivePayload })
                 });
 
                 if (response.status === 403) {
@@ -3112,7 +3112,7 @@
                         'x-archive-meta-title': `ikey_emergency_${currentGUID}.json`,
                         'x-archive-meta-mediatype': 'data'
                     },
-                    body: JSON.stringify(archivePayload)
+                    body: JSON.stringify({ data: archivePayload })
                 });
 
                 if (!response.ok) {


### PR DESCRIPTION
## Summary
- Wrap POST/PUT payloads in a `data` field so n8n can forward the full object to archive.org

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae31b344f88332aa5892237d574d4b