### PR TITLE
Fix Xano cache fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -3465,11 +3465,14 @@
 
         async function fetchFromCache(guid) {
             try {
-                const resp = await fetch(`${XANO_BASE}/ikey_cache?guid=${encodeURIComponent(guid)}`);
+                const resp = await fetch(
+                    `${XANO_BASE}/ikey_cache?guid=${encodeURIComponent(guid)}`,
+                    { method: 'GET', mode: 'cors', cache: 'no-store' }
+                );
                 if (!resp.ok) return null;
                 const json = await resp.json();
                 const record = Array.isArray(json) ? json[0] : json;
-                return record ? record.data : null;
+                return record || null;
             } catch (e) {
                 return null;
             }


### PR DESCRIPTION
## Summary
- Ensure Xano cache GET request includes proper options and returns full record

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae88c2ecf08332aca2d03ab5017878