### PR TITLE
Handle multiple Xano cache records by using latest entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -3471,7 +3471,9 @@
                 );
                 if (!resp.ok) return null;
                 const json = await resp.json();
-                const record = Array.isArray(json) ? json[0] : json;
+                const record = Array.isArray(json)
+                    ? json.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0]
+                    : json;
                 return record || null;
             } catch (e) {
                 return null;


### PR DESCRIPTION
## Summary
- Ensure `fetchFromCache` chooses the most recent record based on `created_at` when Xano returns multiple entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae8a58e6788332964f357c2f4534d8