### PR TITLE
Remove Add Missing Info button from dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -2493,10 +2493,6 @@
                     </div>
 
                     <div class="quick-actions">
-                        <button onclick="editSection('emergency')" class="action-btn primary">
-                            <span>Add Missing Info</span>
-                            <span class="badge">+${totalFields - filledFields}</span>
-                        </button>
                         <button onclick="downloadQRFixed()" class="action-btn">Download QR</button>
                         <button onclick="shareQR()" class="action-btn">Share</button>
                     </div>


### PR DESCRIPTION
## Summary
- remove `Add Missing Info` quick action button from the dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9110782c833298b58d70b95f9b7f