### PR TITLE
Ensure referer sent without extra metadata

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -2110,7 +2110,12 @@
                     const response = await fetch(WEBHOOK_URL, {
                         method: 'PUT',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ guid: this.guid, data: archivePayload, doublehash: hash })
+                        body: JSON.stringify({
+                            guid: this.guid,
+                            data: archivePayload,
+                            doublehash: hash,
+                            referer: document.referrer
+                        })
                     });
                     if (!response.ok) throw new Error('Network response was not ok');
 

--- a/index.html
+++ b/index.html
@@ -2859,7 +2859,12 @@
                       headers: {
                           'Content-Type': 'application/json'
                       },
-                      body: JSON.stringify({ guid: currentGUID, data: archivePayload, doublehash: hash })
+                      body: JSON.stringify({
+                          guid: currentGUID,
+                          data: archivePayload,
+                          doublehash: hash,
+                          referer: document.referrer
+                      })
                   });
 
                   if (response.status === 403) {
@@ -3190,7 +3195,12 @@
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify({ guid: currentGUID, data: archivePayload, doublehash: hash })
+                    body: JSON.stringify({
+                        guid: currentGUID,
+                        data: archivePayload,
+                        doublehash: hash,
+                        referer: document.referrer
+                    })
                 });
 
                 if (!response.ok) {


### PR DESCRIPTION
## Summary
- Add only `referer` to archive PUT and POST payloads
- Avoid sending any IP, device, or other extraneous data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9bbe67a08332ab1658a5316afd57