### PR TITLE
Refine EHR access in dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -359,7 +359,7 @@
             <div class="nav-center">
                 <a href="index.html" class="nav-link active">Dashboard</a>
                 <a href="#" class="nav-link">Emergency View</a>
-                <a href="#" class="nav-link">EHR</a>
+                <a href="#" class="nav-link">🩺 EHR</a>
                 <a href="#" class="nav-link">Settings</a>
             </div>
             <div class="nav-right">

--- a/index.html
+++ b/index.html
@@ -1519,7 +1519,7 @@
                 <div class="lang-dropdown"></div>
             </div>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>
-            <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">EHR</button>
+            <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
             <button class="login-btn" onclick="ownerLogin()">Owner Login</button>
             <div id="session-timer" class="session-timer">
                 <span id="session-countdown"></span>
@@ -2543,6 +2543,9 @@
         function renderSectionCard(title, icon, progress, fields, onClick, sectionKey) {
             const percent = Math.round((progress.filled / progress.total) * 100);
             const clickAttr = onClick ? ` onclick="${onClick}" style="cursor:pointer"` : '';
+            const actionButton = sectionKey === 'vault'
+                ? `<button class="edit-section-btn" onclick="event.stopPropagation(); showHealthRecordsTab()">Open</button>`
+                : `<button class="edit-section-btn" onclick="event.stopPropagation(); openEditModal('${sectionKey}')">Edit</button>`;
             return `
                 <div class="section-card ${percent === 100 ? 'complete' : ''}"${clickAttr}>
                     <div class="section-header">
@@ -2563,7 +2566,7 @@
                             </div>
                         `).join('')}
                     </div>
-                    <button class="edit-section-btn" onclick="event.stopPropagation(); openEditModal('${sectionKey}')">Edit</button>
+                    ${actionButton}
                 </div>
             `;
         }


### PR DESCRIPTION
## Summary
- Display a stethoscope icon next to EHR links in dashboard and top bar
- Replace Edit action for EHR section with Open that triggers health records view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9c44e74c8332be46fd38ff3ce4a0