### PR TITLE
Fix navigation after failed login

### DIFF
--- a/index.html
+++ b/index.html
@@ -2403,9 +2403,21 @@
             }, duration);
         }
 
-        function verifyOwnerPassword(password) {
-            // Manual auth override - skip verification
-            return Promise.resolve(true);
+        async function verifyOwnerPassword(password) {
+            // Check stored hash to confirm password before allowing owner access
+            if (!currentBlob?.privateInfo?.encryptedWith) {
+                return true; // nothing to verify
+            }
+            try {
+                const hash = await sha256Hash(currentKey + password);
+                if (hash === currentBlob.privateInfo.encryptedWith) {
+                    return true;
+                }
+            } catch (e) {
+                console.error('Password verification failed', e);
+            }
+            alert('Incorrect password');
+            return false;
         }
 
         function showOwnerDashboard() {


### PR DESCRIPTION
## Summary
- verify owner password against stored hash before showing dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9ebe3fd4833296ae9122d6c8aba8