### PR TITLE
Handle single-record Xano cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -1626,6 +1626,9 @@
             if (typeof record.id !== 'undefined') {
                 return Number(record.id) || 0;
             }
+            if (record.updated_at) {
+                return new Date(record.updated_at).getTime();
+            }
             if (record.created_at) {
                 return new Date(record.created_at).getTime();
             }
@@ -3525,10 +3528,7 @@
                     { method: 'GET', mode: 'cors', cache: 'no-store' }
                 );
                 if (!resp.ok) return null;
-                const json = await resp.json();
-                const record = Array.isArray(json)
-                    ? json.sort((a, b) => getRecordOrder(b) - getRecordOrder(a))[0]
-                    : json;
+                const record = await resp.json();
                 return record || null;
             } catch (e) {
                 return null;


### PR DESCRIPTION
## Summary
- Support new Xano response without `created_at` by checking `updated_at` as the timestamp fallback
- Simplify cache fetch to treat Xano response as a single record object

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9e68b15c8332b09bb4c70f377381