### PR TITLE
feat: make resources tab full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
             width: 100%;
         }
 
+        #resourcesTab {
+            width: 100%;
+        }
+
         .container {
             width: 100% !important;
             max-width: none;


### PR DESCRIPTION
## Summary
- ensure the resources tab spans the full width so its iframe embed uses all available space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aea59ac36483329d0ae988182a9079