### PR TITLE
Scale embedded frames with text size

### DIFF
--- a/index.html
+++ b/index.html
@@ -3994,7 +3994,8 @@
                 document.getElementById('resourcesTab').style.display = 'none';
                 const frame = document.getElementById('healthRecordsFrame');
                 const setFrameHeight = () => {
-                    frame.style.height = window.innerHeight + 'px';
+                    const scale = window.getCurrentScale ? window.getCurrentScale() : 1;
+                    frame.style.height = (window.innerHeight / scale) + 'px';
                 };
                 setFrameHeight();
                 window.addEventListener('resize', setFrameHeight);
@@ -4013,7 +4014,8 @@
             document.getElementById('text911Tab').style.display = 'none';
             const frame = document.getElementById('resourcesFrame');
             const setFrameHeight = () => {
-                frame.style.height = window.innerHeight + 'px';
+                const scale = window.getCurrentScale ? window.getCurrentScale() : 1;
+                frame.style.height = (window.innerHeight / scale) + 'px';
             };
             setFrameHeight();
             window.addEventListener('resize', setFrameHeight);

--- a/text-size.js
+++ b/text-size.js
@@ -1,9 +1,33 @@
 (function(){
   const sizes = { standard: '16px', large: '20px', xlarge: '24px', xxlarge: '32px' };
+  const scaleFactors = { standard: 1, large: 1.25, xlarge: 1.5, xxlarge: 2 };
   const order = Object.keys(sizes);
+
+  function applySizeToEmbeds(size) {
+    const scale = scaleFactors[size] || 1;
+    ['healthRecordsFrame', 'resourcesFrame'].forEach(id => {
+      const frame = document.getElementById(id);
+      if (!frame) return;
+      frame.style.transformOrigin = '0 0';
+      frame.style.transform = `scale(${scale})`;
+      frame.style.width = (100 / scale) + '%';
+      frame.style.height = (window.innerHeight / scale) + 'px';
+      try {
+        if (frame.contentWindow && typeof frame.contentWindow.applyTextSize === 'function') {
+          frame.contentWindow.applyTextSize(size);
+        }
+      } catch (e) {}
+    });
+  }
+
+  window.getCurrentScale = function() {
+    const current = localStorage.getItem('ikey_text_size') || 'standard';
+    return scaleFactors[current] || 1;
+  };
 
   window.applyTextSize = function(size) {
     document.documentElement.style.fontSize = sizes[size] || sizes.standard;
+    applySizeToEmbeds(size);
   };
 
   window.changeTextSize = function(delta) {
@@ -13,6 +37,12 @@
     localStorage.setItem('ikey_text_size', next);
     applyTextSize(next);
   };
+
+  window.addEventListener('storage', e => {
+    if (e.key === 'ikey_text_size') {
+      applyTextSize(e.newValue);
+    }
+  });
 
   const savedSize = localStorage.getItem('ikey_text_size') || 'standard';
   applyTextSize(savedSize);


### PR DESCRIPTION
## Summary
- Scale embedded EHR and WTTIN frames in sync with text size adjustments
- Sync text size changes across frames and windows via storage events
- Compute iframe heights using current zoom scale

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aeae93a9fc8332bd5811bd468a360c