### PR TITLE
Ensure autosave waits 15s and last updated reflects PUTs

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -1769,13 +1769,13 @@
                 this.hasUnsavedChanges = true;
                 this.updateSaveStatus();
 
-                // Auto-save shortly after changes
+                // Auto-save after 15 seconds of inactivity
                 if (this.autoSaveTimeout) clearTimeout(this.autoSaveTimeout);
                 this.autoSaveTimeout = setTimeout(() => {
                     if (this.sessionPassword && !this.isLocked) {
                         this.performSave(this.sessionPassword, true);
                     }
-                }, 1000);
+                }, 15000);
 
                 // Clear existing reminder
                 if (this.saveReminderTimeout) clearTimeout(this.saveReminderTimeout);
@@ -2081,8 +2081,7 @@
                 const formData = this.collectFormData();
                 const timestamp = new Date().toLocaleString();
 
-                // Update last updated
-                document.getElementById('lastUpdated').textContent = timestamp;
+                // Record intended update time in payload
                 formData.lastUpdated = timestamp;
 
                 try {
@@ -2121,6 +2120,10 @@
                         })
                     });
                     if (!response.ok) throw new Error('Network response was not ok');
+
+                    // Update last updated display only after successful save
+                    const lastUpdatedEl = document.getElementById('lastUpdated');
+                    if (lastUpdatedEl) lastUpdatedEl.textContent = timestamp;
 
                     const src = document.getElementById('hr-source');
                     if (src) src.textContent = 'Source: Server cache';

--- a/session.js
+++ b/session.js
@@ -216,8 +216,6 @@ class SessionManager {
             status.textContent = 'Saved';
             setTimeout(() => { status.textContent = ''; }, 2000);
         }
-        const updated = document.getElementById('last-updated-time');
-        if (updated) updated.textContent = new Date().toLocaleString();
     }
 
     saveToArchive(data) {


### PR DESCRIPTION
## Summary
- Delay health record auto-save until 15s after last edit
- Update last updated timestamp only after successful PUT requests
- Remove autosave from altering last updated display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aeaf5f72908332bb3853f8e3e738c2