### PR TITLE
feat: show profile artwork

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -128,14 +128,8 @@
         .avatar {
             width: 80px;
             height: 80px;
-            background: linear-gradient(135deg, #667eea, #764ba2);
             border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: white;
-            font-size: 32px;
-            font-weight: bold;
+            object-fit: cover;
         }
         
         .profile-info h1 {
@@ -375,7 +369,7 @@
         <div class="profile-header">
             <div class="profile-top">
                 <div class="profile-identity">
-                    <div class="avatar">SC</div>
+                    <img src="https://storage.googleapis.com/art_homelessness/1.png" alt="Woman with backpack" class="avatar">
                     <div class="profile-info">
                         <h1>Sarah Chen</h1>
                         <div class="profile-meta">Female • 34 years • San Francisco, CA</div>


### PR DESCRIPTION
## Summary
- show woman-with-backpack artwork in dashboard profile header
- style avatar for image display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb07db09083329a1469b3156d1f8a