### PR TITLE
fix: prevent EHR iframe from being cut off

### DIFF
--- a/index.html
+++ b/index.html
@@ -4026,7 +4026,9 @@
                 const frame = document.getElementById('healthRecordsFrame');
                 const setFrameHeight = () => {
                     const scale = window.getCurrentScale ? window.getCurrentScale() : 1;
-                    frame.style.height = (window.innerHeight / scale) + 'px';
+                    const topBar = document.querySelector('.top-bar');
+                    const offset = topBar ? topBar.offsetHeight : 0;
+                    frame.style.height = ((window.innerHeight - offset) / scale) + 'px';
                 };
                 setFrameHeight();
                 window.addEventListener('resize', setFrameHeight);
@@ -4046,7 +4048,9 @@
             const frame = document.getElementById('resourcesFrame');
             const setFrameHeight = () => {
                 const scale = window.getCurrentScale ? window.getCurrentScale() : 1;
-                frame.style.height = (window.innerHeight / scale) + 'px';
+                const topBar = document.querySelector('.top-bar');
+                const offset = topBar ? topBar.offsetHeight : 0;
+                frame.style.height = ((window.innerHeight - offset) / scale) + 'px';
             };
             setFrameHeight();
             window.addEventListener('resize', setFrameHeight);


### PR DESCRIPTION
## Summary
- adjust health records iframe height to subtract top bar and prevent clipping
- apply same top bar height adjustment to resources iframe

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb24f22c48332bbb3b0671b3debf1