### PR TITLE
Prefer Xano cache before Archive

### DIFF
--- a/health-records.html
+++ b/health-records.html
@@ -1496,6 +1496,7 @@
     <script src="session.js"></script>
     <script>
         const ARCHIVE_BASE = 'https://archive.org/download/zuboff/';
+        const XANO_BASE = 'https://xvkq-pq7i-idtl.n7d.xano.io/api:Hj4C6PGO';
         const WEBHOOK_URL = 'https://n8n.intelechia.com/webhook/d5e99c29-2cf1-44c1-b5b4-95a1ca048441';
 
         // Application class to manage state and functionality
@@ -1573,15 +1574,35 @@
 
             async loadArchiveData() {
                 try {
-                    const archiveUrl = `${ARCHIVE_BASE}${this.guid}.json?ts=${Date.now()}`;
-                    const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
-                    if (!response.ok) return;
-                    const archiveData = await response.json();
+                    let archiveData = null;
+                    let source = '';
+
+                    try {
+                        const resp = await fetch(
+                            `${XANO_BASE}/ikey_cache?guid=${encodeURIComponent(this.guid)}`,
+                            { method: 'GET', mode: 'cors', cache: 'no-store' }
+                        );
+                        if (resp.ok) {
+                            archiveData = await resp.json();
+                            source = 'Server cache';
+                        }
+                    } catch (e) {
+                        console.log('Cache fetch failed:', e.message);
+                    }
+
+                    if (!archiveData) {
+                        const archiveUrl = `${ARCHIVE_BASE}${this.guid}.json?ts=${Date.now()}`;
+                        const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
+                        if (!response.ok) return;
+                        archiveData = await response.json();
+                        source = 'Archive.org';
+                    }
+
                     const payload = await this.crypto.decrypt(archiveData.data, this.sessionPassword);
                     if (payload.healthRecords) {
                         this.loadFormData(payload.healthRecords);
                         const src = document.getElementById('hr-source');
-                        if (src) src.textContent = 'Source: Archive.org';
+                        if (src) src.textContent = `Source: ${source}`;
                     }
                 } catch (e) {
                     console.warn('No existing health records found', e);
@@ -2087,10 +2108,26 @@
                 try {
                     let existing = {};
                     try {
-                        const archiveUrl = `${ARCHIVE_BASE}${this.guid}.json?ts=${Date.now()}`;
-                        const existingResp = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
-                        if (existingResp.ok) {
-                            const existingData = await existingResp.json();
+                        let existingData = null;
+                        try {
+                            const cacheResp = await fetch(
+                                `${XANO_BASE}/ikey_cache?guid=${encodeURIComponent(this.guid)}`,
+                                { method: 'GET', mode: 'cors', cache: 'no-store' }
+                            );
+                            if (cacheResp.ok) {
+                                existingData = await cacheResp.json();
+                            }
+                        } catch (err) {
+                            console.log('Cache fetch failed:', err.message);
+                        }
+                        if (!existingData) {
+                            const archiveUrl = `${ARCHIVE_BASE}${this.guid}.json?ts=${Date.now()}`;
+                            const existingResp = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
+                            if (existingResp.ok) {
+                                existingData = await existingResp.json();
+                            }
+                        }
+                        if (existingData) {
                             existing = await this.crypto.decrypt(existingData.data, password);
                         }
                     } catch (e) {

--- a/index.html
+++ b/index.html
@@ -1914,19 +1914,19 @@
 
             try {
                 let archiveData;
-                let source = 'Archive.org';
-                try {
+                let source = '';
+                const cache = await fetchFromCache(guid);
+                if (cache) {
+                    archiveData = cache;
+                    source = 'Server cache';
+                } else {
                     const response = await fetch(
                         `${ARCHIVE_BASE}${guid}.json?ts=${Date.now()}`,
                         { mode: 'cors', cache: 'no-store' }
                     );
                     if (!response.ok) throw new Error('Not found');
                     archiveData = await response.json();
-                } catch (err) {
-                    const cache = await fetchFromCache(guid);
-                    if (!cache) throw err;
-                    archiveData = cache;
-                    source = 'Server cache';
+                    source = 'Archive.org';
                 }
                 currentSource = source;
                 const decrypted = await decrypt(archiveData.editable, key);
@@ -1994,35 +1994,25 @@
         async function fetchFromArchive(guid, key) {
             const cache = await fetchFromCache(guid);
             let chosen = null;
-            let chosenTime = 0;
             let source = '';
 
             if (cache) {
                 chosen = cache;
-                chosenTime = getRecordOrder(cache);
                 source = 'Server cache';
                 console.log('Loaded from Xano cache');
-            }
-
-            try {
-                const archiveUrl = `${ARCHIVE_BASE}${guid}.json?ts=${Date.now()}`;
-                const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
-                if (response.ok) {
-                    const archiveData = await response.json();
-                    const archiveOrder = getRecordOrder(archiveData);
-                    if (!chosen || archiveOrder > chosenTime) {
-                        chosen = archiveData;
-                        chosenTime = archiveOrder;
+            } else {
+                try {
+                    const archiveUrl = `${ARCHIVE_BASE}${guid}.json?ts=${Date.now()}`;
+                    const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
+                    if (response.ok) {
+                        chosen = await response.json();
                         source = 'Archive.org';
-                        console.log('Using newer data from Archive.org');
                     } else {
-                        console.log('Xano cache is newer than Archive.org');
+                        console.log('Archive.org response status:', response.status);
                     }
-                } else {
-                    console.log('Archive.org response status:', response.status);
+                } catch (e) {
+                    console.log('Archive fetch failed:', e.message);
                 }
-            } catch (e) {
-                console.log('Archive fetch failed:', e.message);
             }
 
             if (chosen) {
@@ -2086,31 +2076,33 @@
                 console.log('Cache fetch failed:', e.message);
             }
 
-            try {
-                const archiveUrl = `${ARCHIVE_BASE}${guid}.json?ts=${Date.now()}`;
-                console.log('Fetching from Archive.org:', archiveUrl);
+            if (!fetchSuccess) {
+                try {
+                    const archiveUrl = `${ARCHIVE_BASE}${guid}.json?ts=${Date.now()}`;
+                    console.log('Fetching from Archive.org:', archiveUrl);
 
-                const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
-                console.log('Archive.org response status:', response.status);
+                    const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
+                    console.log('Archive.org response status:', response.status);
 
-                if (response.ok) {
-                    const archiveData = await response.json();
-                    const cacheOrder = data ? getRecordOrder(data) : 0;
-                    const archiveOrder = getRecordOrder(archiveData);
+                    if (response.ok) {
+                        const archiveData = await response.json();
+                        const cacheOrder = data ? getRecordOrder(data) : 0;
+                        const archiveOrder = getRecordOrder(archiveData);
 
-                    if (!data || archiveOrder > cacheOrder) {
-                        data = archiveData;
-                        source = 'Archive.org';
-                        console.log('Using newer data from Archive.org');
+                        if (!data || archiveOrder > cacheOrder) {
+                            data = archiveData;
+                            source = 'Archive.org';
+                            console.log('Using newer data from Archive.org');
+                        } else {
+                            console.log('Xano cache is newer than Archive.org');
+                        }
+                        fetchSuccess = true;
                     } else {
-                        console.log('Xano cache is newer than Archive.org');
+                        throw new Error('Not found on Archive.org');
                     }
-                    fetchSuccess = true;
-                } else {
-                    throw new Error('Not found on Archive.org');
+                } catch (error) {
+                    console.log('Archive fetch failed:', error.message);
                 }
-            } catch (error) {
-                console.log('Archive fetch failed:', error.message);
             }
 
             if (!fetchSuccess) {
@@ -2398,6 +2390,11 @@
         }
 
         function showOwnerDashboard() {
+            if (!currentBlob) {
+                console.error('Cannot show dashboard - no data loaded');
+                alert('No data loaded for this iKey.');
+                return;
+            }
             // Ensure the dashboard content is visible regardless of the current tab
             document.getElementById('qrTab').style.display = 'block';
             document.getElementById('text911Tab').style.display = 'none';
@@ -3710,17 +3707,19 @@
                 console.log('Cache fetch failed:', e.message);
             }
 
+            if (cache) {
+                document.getElementById('dev-output').textContent =
+                    `Loaded from Xano backup\n\nRaw JSON:\n${JSON.stringify(cache, null, 2)}`;
+                return;
+            }
+
             try {
                 const archiveUrl = `${ARCHIVE_BASE}${guid}.json?ts=${Date.now()}`;
                 const response = await fetch(archiveUrl, { mode: 'cors', cache: 'no-store' });
                 if (response.ok) {
                     const archiveData = await response.json();
-                    const cacheOrder = cache ? getRecordOrder(cache) : 0;
-                    const archiveOrder = getRecordOrder(archiveData);
-                    const latest = !cache || archiveOrder > cacheOrder ? archiveData : cache;
-                    const source = !cache || archiveOrder > cacheOrder ? 'Archive.org' : 'Xano backup';
                     document.getElementById('dev-output').textContent =
-                        `Loaded from ${source}\n\nRaw JSON:\n${JSON.stringify(latest, null, 2)}`;
+                        `Loaded from Archive.org\n\nRaw JSON:\n${JSON.stringify(archiveData, null, 2)}`;
                     return;
                 }
                 console.log('Archive.org response status:', response.status);
@@ -3728,13 +3727,8 @@
                 console.log('Archive fetch failed:', error.message);
             }
 
-            if (cache) {
-                document.getElementById('dev-output').textContent =
-                    `Loaded from Xano backup\n\nRaw JSON:\n${JSON.stringify(cache, null, 2)}`;
-            } else {
-                document.getElementById('dev-output').textContent =
-                    `Not found on Archive.org or Xano backup.`;
-            }
+            document.getElementById('dev-output').textContent =
+                `Not found on Archive.org or Xano backup.`;
         }
         
         async function devScanQR() {


### PR DESCRIPTION
## Summary
- Load emergency data from Xano cache before Archive.org to avoid CORS failures
- Protect owner dashboard from launching without loaded data
- Health record page fetches and saves via Xano before attempting Archive.org

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68afbf7547b8833281d84ba6d169eaaa