### PR TITLE
Fix missing style wrapper in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,6 +363,7 @@
             });
         });
     </script>
+        <style>
         @keyframes spin {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
@@ -1439,8 +1440,6 @@
             }
         }
     </style>
-</head>
-<body>
     <div class="top-bar">
         <div class="logo-container">
             <div class="logo">🔑 <span class="logo-text-full">iKey</span><span class="logo-text-short">iKey</span></div>


### PR DESCRIPTION
## Summary
- wrap stray CSS in a `<style>` tag so it is applied instead of rendered as text
- remove extra `</head>`/`<body>` tags to clean up document structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68afc0d19fbc833286c69a7a99cb0ed3