### PR TITLE
refactor: separate landing page from SPA and tweak layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,6 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
             padding: 20px;
         }
         
@@ -251,119 +248,7 @@
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="header">
-            <div class="logo">iKey</div>
-            <div class="tagline">Secure Personal Information Vault</div>
-            <div class="security-badge">
-                🔐 Zero-Knowledge Encryption
-            </div>
-        </div>
-        
-        <div class="options-grid">
-            <div class="option-card" onclick="handlePersonalSetup()">
-                <div class="recommended-badge">Recommended</div>
-                <div class="icon">👤</div>
-                <h2 class="option-title">Personal QR Code</h2>
-                <p class="option-description">
-                    Create your own secure iKey QR code to protect and share your personal information with zero-knowledge encryption.
-                </p>
-                <ul class="features-list">
-                    <li>One-time QR generation (never changes)</li>
-                    <li>Three-layer encryption security</li>
-                    <li>Emergency & private info separation</li>
-                    <li>Password-protected access</li>
-                    <li>Auto-archive updates</li>
-                </ul>
-                <button class="action-button">
-                    <span>➜</span>
-                    <span>Get Started</span>
-                </button>
-            </div>
-            
-            <div class="option-card" onclick="handleBulkGeneration()">
-                <div class="icon">📋</div>
-                <h2 class="option-title">Bulk QR Generation</h2>
-                <p class="option-description">
-                    Generate multiple QR codes for organizations, events, or distribution. Perfect for healthcare facilities, schools, or emergency services.
-                </p>
-                <ul class="features-list">
-                    <li>Batch create up to 1000 codes</li>
-                    <li>Print-ready layouts</li>
-                    <li>Customizable page formats</li>
-                    <li>CSV import for bulk data</li>
-                    <li>Admin management dashboard</li>
-                </ul>
-                
-                <div class="bulk-details">
-                    <strong style="color: #4b5563;">Printing Specifications</strong>
-                    <div class="bulk-specs">
-                        <div class="spec-item">
-                            <span class="spec-value">15mm</span>
-                            <span class="spec-label">Min. QR Size</span>
-                        </div>
-                        <div class="spec-item">
-                            <span class="spec-value">1-30</span>
-                            <span class="spec-label">Codes per Page</span>
-                        </div>
-                        <div class="spec-item">
-                            <span class="spec-value">A4/Letter</span>
-                            <span class="spec-label">Page Formats</span>
-                        </div>
-                    </div>
-                </div>
-                
-                <button class="action-button" style="margin-top: 20px;">
-                    <span>⚡</span>
-                    <span>Configure Bulk</span>
-                </button>
-            </div>
-        </div>
-        
-        <div class="footer-info">
-            <strong>Security First</strong>
-            <div class="encryption-info">
-                <div class="encryption-item">
-                    <span>🔑</span>
-                    <span>256-bit Encryption</span>
-                </div>
-                <div class="encryption-item">
-                    <span>🛡️</span>
-                    <span>PBKDF2 Key Derivation</span>
-                </div>
-                <div class="encryption-item">
-                    <span>📦</span>
-                    <span>Zero-Knowledge Architecture</span>
-                </div>
-            </div>
-        </div>
-    </div>
-    <script>
-        function handlePersonalSetup() {
-            window.location.href = 'personal.html';
-        }
-        
-        function handleBulkGeneration() {
-            window.location.href = 'bulk.html';
-        }
-        
-        document.addEventListener('DOMContentLoaded', () => {
-            const cards = document.querySelectorAll('.option-card');
-            cards.forEach((card, index) => {
-                setTimeout(() => {
-                    card.style.opacity = '0';
-                    card.style.transform = 'translateY(20px)';
-                    card.style.transition = 'all 0.5s ease';
-                    
-                    setTimeout(() => {
-                        card.style.opacity = '1';
-                        card.style.transform = 'translateY(0)';
-                    }, 100);
-                }, index * 100);
-            });
-        });
-    </script>
-        <style>
+    <style>
         @keyframes spin {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
@@ -1453,6 +1338,7 @@
                 <button class="lang-button" onclick="toggleLangDropdown()"><span id="current-language">EN</span> ▼</button>
                 <div class="lang-dropdown"></div>
             </div>
+            <button class="home-btn" onclick="window.location='landing.html'">Home</button>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>
             <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
             <button class="notes-tab-btn" style="display:none;" onclick="window.location='notes.html'">📝 Notes</button>

--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>iKey - Secure Personal Information Vault</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        
+        .container {
+            max-width: 1200px;
+            width: 100%;
+            background: rgba(255, 255, 255, 0.98);
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+            padding: 60px 40px;
+        }
+        
+        .header {
+            text-align: center;
+            margin-bottom: 50px;
+        }
+        
+        .logo {
+            font-size: 48px;
+            font-weight: bold;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            margin-bottom: 10px;
+        }
+        
+        .tagline {
+            color: #6b7280;
+            font-size: 18px;
+            margin-bottom: 5px;
+        }
+        
+        .security-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            background: #f3f4f6;
+            padding: 5px 15px;
+            border-radius: 20px;
+            font-size: 14px;
+            color: #4b5563;
+            margin-top: 10px;
+        }
+        
+        .options-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+            gap: 30px;
+            margin-bottom: 40px;
+        }
+        
+        .option-card {
+            background: #fff;
+            border: 2px solid #e5e7eb;
+            border-radius: 15px;
+            padding: 40px;
+            transition: all 0.3s ease;
+            cursor: pointer;
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .option-card:hover {
+            border-color: #667eea;
+            transform: translateY(-5px);
+            box-shadow: 0 10px 20px rgba(102, 126, 234, 0.2);
+        }
+        
+        .option-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 4px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            transform: scaleX(0);
+            transition: transform 0.3s ease;
+        }
+        
+        .option-card:hover::before {
+            transform: scaleX(1);
+        }
+        
+        .icon {
+            width: 60px;
+            height: 60px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border-radius: 15px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 20px;
+            font-size: 30px;
+            color: white;
+        }
+        
+        .option-title {
+            font-size: 24px;
+            font-weight: bold;
+            color: #1f2937;
+            margin-bottom: 15px;
+        }
+        
+        .option-description {
+            color: #6b7280;
+            line-height: 1.6;
+            margin-bottom: 20px;
+        }
+        
+        .features-list {
+            list-style: none;
+        }
+        
+        .features-list li {
+            color: #4b5563;
+            padding: 8px 0;
+            padding-left: 25px;
+            position: relative;
+        }
+        
+        .features-list li:before {
+            content: '✓';
+            position: absolute;
+            left: 0;
+            color: #10b981;
+            font-weight: bold;
+        }
+        
+        .bulk-details {
+            background: #f9fafb;
+            border-radius: 10px;
+            padding: 20px;
+            margin-top: 20px;
+        }
+        
+        .bulk-specs {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 15px;
+            margin-top: 15px;
+        }
+        
+        .spec-item {
+            text-align: center;
+            padding: 10px;
+            background: white;
+            border-radius: 8px;
+        }
+        
+        .spec-value {
+            font-size: 20px;
+            font-weight: bold;
+            color: #667eea;
+            display: block;
+        }
+        
+        .spec-label {
+            font-size: 12px;
+            color: #6b7280;
+            margin-top: 5px;
+        }
+        
+        .action-button {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            padding: 12px 30px;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .action-button:hover {
+            transform: scale(1.05);
+            box-shadow: 0 5px 20px rgba(102, 126, 234, 0.3);
+        }
+        
+        .recommended-badge {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            background: #10b981;
+            color: white;
+            padding: 5px 15px;
+            border-radius: 20px;
+            font-size: 12px;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+        
+        .footer-info {
+            text-align: center;
+            padding-top: 30px;
+            border-top: 1px solid #e5e7eb;
+            color: #6b7280;
+            font-size: 14px;
+        }
+        
+        .encryption-info {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+            margin-top: 15px;
+        }
+        
+        .encryption-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        @media (max-width: 900px) {
+            .options-grid {
+                grid-template-columns: 1fr;
+            }
+            
+            .container {
+                padding: 40px 20px;
+            }
+            
+            .bulk-specs {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="logo">iKey</div>
+            <div class="tagline">Secure Personal Information Vault</div>
+            <div class="security-badge">
+                🔐 Zero-Knowledge Encryption
+            </div>
+        </div>
+        
+        <div class="options-grid">
+            <div class="option-card" onclick="handlePersonalSetup()">
+                <div class="recommended-badge">Recommended</div>
+                <div class="icon">👤</div>
+                <h2 class="option-title">Personal QR Code</h2>
+                <p class="option-description">
+                    Create your own secure iKey QR code to protect and share your personal information with zero-knowledge encryption.
+                </p>
+                <ul class="features-list">
+                    <li>One-time QR generation (never changes)</li>
+                    <li>Three-layer encryption security</li>
+                    <li>Emergency & private info separation</li>
+                    <li>Password-protected access</li>
+                    <li>Auto-archive updates</li>
+                </ul>
+                <button class="action-button">
+                    <span>➜</span>
+                    <span>Get Started</span>
+                </button>
+            </div>
+            
+            <div class="option-card" onclick="handleBulkGeneration()">
+                <div class="icon">📋</div>
+                <h2 class="option-title">Bulk QR Generation</h2>
+                <p class="option-description">
+                    Generate multiple QR codes for organizations, events, or distribution. Perfect for healthcare facilities, schools, or emergency services.
+                </p>
+                <ul class="features-list">
+                    <li>Batch create up to 1000 codes</li>
+                    <li>Print-ready layouts</li>
+                    <li>Customizable page formats</li>
+                    <li>CSV import for bulk data</li>
+                    <li>Admin management dashboard</li>
+                </ul>
+                
+                <div class="bulk-details">
+                    <strong style="color: #4b5563;">Printing Specifications</strong>
+                    <div class="bulk-specs">
+                        <div class="spec-item">
+                            <span class="spec-value">15mm</span>
+                            <span class="spec-label">Min. QR Size</span>
+                        </div>
+                        <div class="spec-item">
+                            <span class="spec-value">1-30</span>
+                            <span class="spec-label">Codes per Page</span>
+                        </div>
+                        <div class="spec-item">
+                            <span class="spec-value">A4/Letter</span>
+                            <span class="spec-label">Page Formats</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <button class="action-button" style="margin-top: 20px;">
+                    <span>⚡</span>
+                    <span>Configure Bulk</span>
+                </button>
+            </div>
+        </div>
+        
+        <div class="footer-info">
+            <strong>Security First</strong>
+            <div class="encryption-info">
+                <div class="encryption-item">
+                    <span>🔑</span>
+                    <span>256-bit Encryption</span>
+                </div>
+                <div class="encryption-item">
+                    <span>🛡️</span>
+                    <span>PBKDF2 Key Derivation</span>
+                </div>
+                <div class="encryption-item">
+                    <span>📦</span>
+                    <span>Zero-Knowledge Architecture</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        function handlePersonalSetup() {
+            window.location.href = 'index.html';
+        }
+        
+        function handleBulkGeneration() {
+            window.location.href = 'bulk.html';
+        }
+        
+        document.addEventListener('DOMContentLoaded', () => {
+            const cards = document.querySelectorAll('.option-card');
+            cards.forEach((card, index) => {
+                setTimeout(() => {
+                    card.style.opacity = '0';
+                    card.style.transform = 'translateY(20px)';
+                    card.style.transition = 'all 0.5s ease';
+                    
+                    setTimeout(() => {
+                        card.style.opacity = '1';
+                        card.style.transform = 'translateY(0)';
+                    }, 100);
+                }, index * 100);
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extract marketing section into new `landing.html`
- remove flex layout from `body` so SPA flows normally
- add navigation links between landing page and main app

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b082e7ec3083329ebe4ce202c8cf50