### PR TITLE
Fix landing page links and add bulk placeholder

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bulk QR Generation - Coming Soon</title>
+</head>
+<body>
+  <h1>Bulk QR Generation</h1>
+  <p>This feature is coming soon.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
     </div>
     <script>
         function handlePersonalSetup() {
-            window.location.href = 'personal.html';
+            window.location.href = 'dashboard.html';
         }
         
         function handleBulkGeneration() {


### PR DESCRIPTION
## Summary
- Redirect personal setup link to existing dashboard page
- Add placeholder bulk.html so landing page link works

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0848947008332b276d6dfae30fa45