### PR TITLE
Add dynamic top bar offset for app runtime

### DIFF
--- a/app.html
+++ b/app.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>iKey App</title>
+  <style>
+    :root {
+      --top-bar-height: 0px;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+    .top-bar {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: white;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 20px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      z-index: 1000;
+    }
+    main {
+      padding-top: var(--top-bar-height);
+      scroll-margin-top: var(--top-bar-height);
+    }
+  </style>
+</head>
+<body>
+  <div class="top-bar">
+    <div class="logo">iKey</div>
+  </div>
+  <main class="main">
+    <h1>Welcome to iKey</h1>
+    <p>Your secure information vault.</p>
+  </main>
+  <script>
+    function updateTopBarOffset() {
+      const topBar = document.querySelector('.top-bar');
+      const height = topBar ? topBar.offsetHeight : 0;
+      document.documentElement.style.setProperty('--top-bar-height', height + 'px');
+    }
+    window.addEventListener('load', updateTopBarOffset);
+    window.addEventListener('resize', updateTopBarOffset);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new app runtime page that accounts for fixed top bar height
- update page padding and scroll margin via CSS variable on load and resize
- ensure marketing page remains unaffected by offset logic

## Testing
- ⚠️ `npm install puppeteer@21.7.0 && node <viewport test>` (403 Forbidden while fetching package)

------
https://chatgpt.com/codex/tasks/task_b_68b08bbd287c8332ab1519359d6e50ad