### PR TITLE
feat: add permission gate utility

### DIFF
--- a/app.js
+++ b/app.js
@@ -385,32 +385,32 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
       }
 
-      if (!("geolocation" in navigator)) {
-        alert("Geolocation not available on this device/browser.");
+      const { ok, value } = await permissionGate('geolocation', {
+        enableHighAccuracy: true,
+        timeout: 15000,
+        maximumAge: 0
+      });
+      if (!ok) {
+        alert("Couldn't get your location. You can switch to 'Enter coordinates'.");
         return;
       }
-      navigator.geolocation.getCurrentPosition(async pos => {
-        const lat = round6(pos.coords.latitude);
-        const lng = round6(pos.coords.longitude);
-        if (!validLatLng(lat, lng)) {
-          alert("Got invalid coordinates from the device.");
-          return;
-        }
-        const place = {
-          id: uid(),
-          title,
-          note,
-          category: selectedCategory,
-          type: "coords",
-          coords: { lat, lng },
-          createdAt: Date.now()
-        };
-        await savePlaceNote(place);
-        reset();
-      }, err => {
-        alert("Couldn't get your location. You can switch to 'Enter coordinates'.");
-        console.error(err);
-      }, { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 });
+      const lat = round6(value.coords.latitude);
+      const lng = round6(value.coords.longitude);
+      if (!validLatLng(lat, lng)) {
+        alert("Got invalid coordinates from the device.");
+        return;
+      }
+      const place = {
+        id: uid(),
+        title,
+        note,
+        category: selectedCategory,
+        type: "coords",
+        coords: { lat, lng },
+        createdAt: Date.now()
+      };
+      await savePlaceNote(place);
+      reset();
       return;
     }
 

--- a/index.html
+++ b/index.html
@@ -1498,6 +1498,7 @@
     <!-- QR Libraries -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js"></script>
+    <script src="permission-gate.js"></script>
     <script src="app.js"></script>
     <script src="medication.js"></script>
     <script src="text-size.js"></script>
@@ -3782,21 +3783,17 @@
             try {
                 document.getElementById('location-permission-prompt').style.display = 'none';
                 document.getElementById('location-loading').style.display = 'block';
-                await navigator.geolocation.getCurrentPosition(
-                    (position) => {
-                        location911Enabled = true;
-                        document.getElementById('location-loading').style.display = 'none';
-                        document.getElementById('location-content').style.display = 'block';
-                        const iframe = document.getElementById('text911Frame');
-                        iframe.src = 'text911.html';
-                    },
-                    (error) => {
-                        document.getElementById('location-loading').style.display = 'none';
-                        document.getElementById('location-permission-prompt').style.display = 'block';
-                        alert('Location access is required for 911 emergency features. Please enable location in your browser settings.');
-                    },
-                    { enableHighAccuracy: true }
-                );
+                const { ok } = await permissionGate('geolocation', { enableHighAccuracy: true });
+                document.getElementById('location-loading').style.display = 'none';
+                if (ok) {
+                    location911Enabled = true;
+                    document.getElementById('location-content').style.display = 'block';
+                    const iframe = document.getElementById('text911Frame');
+                    iframe.src = 'text911.html';
+                } else {
+                    document.getElementById('location-permission-prompt').style.display = 'block';
+                    alert('Location access is required for 911 emergency features. Please enable location in your browser settings.');
+                }
             } catch (error) {
                 document.getElementById('location-loading').style.display = 'none';
                 document.getElementById('location-permission-prompt').style.display = 'block';

--- a/notes.html
+++ b/notes.html
@@ -67,6 +67,7 @@
         .success-message { position:fixed; top:70px; right:20px; background:#28a745; color:white; padding:12px 20px; border-radius:8px; box-shadow:0 4px 12px rgba(40,167,69,0.2); display:none; z-index:1000; animation:slideIn .3s ease; }
         @keyframes slideIn { from{transform:translateX(400px);} to{transform:translateX(0);} }
     </style>
+    <script src="permission-gate.js"></script>
     <script src="app.js"></script>
 </head>
 <body>
@@ -154,18 +155,24 @@
             displayNotes();
         }
 
-        function toggleLocation(){
-            const toggle = document.getElementById('locationToggle');
-            const status = document.getElementById('locationStatus');
+        async function toggleLocation(){
+            const toggle=document.getElementById('locationToggle');
+            const status=document.getElementById('locationStatus');
             if(toggle.checked){
-                if(navigator.geolocation){
-                    navigator.geolocation.getCurrentPosition(pos=>{
-                        currentLocation={lat:pos.coords.latitude,lng:pos.coords.longitude};
-                        status.className='location-status active';
-                        status.textContent='✓ Location captured';
-                    },()=>{toggle.checked=false; currentLocation=null; alert('Location access denied');});
-                } else { toggle.checked=false; alert('Location services not available.'); }
-            } else { currentLocation=null; status.className='location-status'; }
+                const {ok,value,reason}=await permissionGate('geolocation',{enableHighAccuracy:true});
+                if(ok){
+                    currentLocation={lat:value.coords.latitude,lng:value.coords.longitude};
+                    status.className='location-status active';
+                    status.textContent='✓ Location captured';
+                }else{
+                    toggle.checked=false;
+                    currentLocation=null;
+                    alert(reason==='denied'?'Location access denied':'Location services not available.');
+                }
+            }else{
+                currentLocation=null;
+                status.className='location-status';
+            }
         }
 
         function selectCategory(btn,cat){

--- a/permission-gate.js
+++ b/permission-gate.js
@@ -1,0 +1,38 @@
+// Simple permission gate utility for browser APIs like geolocation
+// Returns a promise resolving to { ok, reason, value }
+// - ok: boolean indicating permission success
+// - reason: optional string describing failure
+// - value: optional granted value (e.g., GeolocationPosition)
+
+async function permissionGate(type, options = {}) {
+  if (type === 'geolocation') {
+    if (!('geolocation' in navigator)) {
+      return { ok: false, reason: 'unsupported' };
+    }
+    try {
+      const position = await new Promise((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject, options);
+      });
+      return { ok: true, value: position };
+    } catch (err) {
+      let reason = 'error';
+      if (typeof err === 'object' && err.code !== undefined) {
+        switch (err.code) {
+          case err.PERMISSION_DENIED:
+            reason = 'denied';
+            break;
+          case err.POSITION_UNAVAILABLE:
+            reason = 'unavailable';
+            break;
+          case err.TIMEOUT:
+            reason = 'timeout';
+            break;
+        }
+      }
+      return { ok: false, reason };
+    }
+  }
+  return { ok: false, reason: 'unsupported' };
+}
+
+window.permissionGate = permissionGate;

--- a/text911.html
+++ b/text911.html
@@ -263,6 +263,7 @@
             body{padding:0;}
         }
     </style>
+    <script src="permission-gate.js"></script>
     <script src="text-size.js"></script>
 </head>
 <body>
@@ -365,7 +366,19 @@
             sendHeight();
         }
         function showError(error){let message='';switch(error.code){case error.PERMISSION_DENIED:message="Location access denied. Please enable it and refresh.";break;case error.POSITION_UNAVAILABLE:message="Location unavailable. Please try again.";break;case error.TIMEOUT:message="Location request timed out. Please refresh.";break;default:message="Unable to get location. Please refresh.";}document.getElementById('errorMessage').textContent=message;document.getElementById('loading').style.display='none';document.getElementById('content').style.display='none';document.getElementById('emergencyButtons').style.display='none';document.getElementById('error').style.display='block';sendHeight();}
-        function getLocation(){if(navigator.geolocation){navigator.geolocation.getCurrentPosition(updateDisplay,showError,{enableHighAccuracy:true,timeout:15000,maximumAge:0});navigator.geolocation.watchPosition(updateDisplay,()=>{},{enableHighAccuracy:true,maximumAge:10000});}else{showError({code:0,message:"Geolocation not supported"});}}
+        async function getLocation(){
+            if(!navigator.geolocation){
+                showError({code:0,message:"Geolocation not supported"});
+                return;
+            }
+            const {ok,value}=await permissionGate('geolocation',{enableHighAccuracy:true,timeout:15000,maximumAge:0});
+            if(ok){
+                updateDisplay(value);
+                navigator.geolocation.watchPosition(updateDisplay,()=>{}, {enableHighAccuracy:true,maximumAge:10000});
+            }else{
+                showError({code:1,message:"Location access denied"});
+            }
+        }
         window.onload=function(){getLocation();};
     </script>
 </body>


### PR DESCRIPTION
## Summary
- create reusable permissionGate utility to standardize permission requests
- use permissionGate for geolocation across app and notes features
- gate emergency text location with permission gate and unify messaging

## Testing
- `node --check permission-gate.js`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_68b08c64fea883329e1288a90bcd95a2