### PR TITLE
Replace internal page links with router navigation

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -52,7 +52,7 @@
 <body>
   <div class="top-bar">
     <div class="logo"><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo"><span>iKey</span></div>
-    <div class="controls"><button onclick="window.location='index.html'">Home</button></div>
+    <div class="controls"><button onclick="router.go('app#index')">Home</button></div>
   </div>
   <div class="container">
     <h1>Bulk QR Generation</h1>

--- a/dashboard.html
+++ b/dashboard.html
@@ -345,9 +345,9 @@
 <body>
     <header class="header">
         <nav class="nav">
-            <a href="index.html" class="logo"><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo"></a>
+            <a href="#" class="logo" onclick="router.go('app#index'); return false;"><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo"></a>
             <div class="nav-center">
-                <a href="index.html" class="nav-link active">Dashboard</a>
+                <a href="#" class="nav-link active" onclick="router.go('app#index'); return false;">Dashboard</a>
                 <a href="#" class="nav-link">Emergency View</a>
                 <a href="#" class="nav-link">🩺 EHR</a>
                 <a href="#" class="nav-link">Settings</a>
@@ -540,7 +540,7 @@
     <script>
     function confirmEmergencyAccess() {
         if (confirm('Open Emergency Services?')) {
-            window.location.href = 'text911.html';
+            router.go('app#text911');
         }
     }
     </script>

--- a/health-records.html
+++ b/health-records.html
@@ -1627,7 +1627,7 @@
                     if (window.parent && window.parent !== window) {
                         window.parent.postMessage({ type: 'closeHealthRecords' }, '*');
                     } else {
-                        window.location.href = 'index.html';
+                        router.go('app#index');
                     }
                 });
                 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
         }
         
         function handleBulkGeneration() {
-            window.location.href = 'bulk.html';
+            router.go('app#bulk');
         }
         
         document.addEventListener('DOMContentLoaded', () => {
@@ -1446,10 +1446,10 @@
                 <button class="lang-button" onclick="toggleLangDropdown()"><span id="current-language">EN</span> ▼</button>
                 <div class="lang-dropdown"></div>
             </div>
-            <button class="home-btn" onclick="window.location='index.html'">Home</button>
+            <button class="home-btn" onclick="router.go('app#index')">Home</button>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>
             <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
-            <button class="notes-tab-btn" style="display:none;" onclick="window.location='notes.html'">📝 Notes</button>
+            <button class="notes-tab-btn" style="display:none;" onclick="router.go('app#notes')">📝 Notes</button>
             <button class="resources-btn" onclick="showResourcesTab()">Resources</button>
             <button class="login-btn" onclick="ownerLogin()">Owner Login</button>
             <div id="session-timer" class="session-timer">
@@ -3731,7 +3731,7 @@
                 setFrameHeight();
                 window.addEventListener('resize', setFrameHeight);
                 if (!frame.src) {
-                    frame.src = 'health-records.html';
+                    frame.src = 'app#health-records';
                 }
                 document.getElementById('healthRecordsTab').style.display = 'block';
             } catch (e) {
@@ -3753,6 +3753,9 @@
             setFrameHeight();
             window.addEventListener('resize', setFrameHeight);
             if (!frame.src) {
+                if (router && router.addBreadcrumb) {
+                    router.addBreadcrumb('Resources', 'https://wttin.org/');
+                }
                 frame.src = 'https://wttin.org/';
             }
             document.getElementById('resourcesTab').style.display = 'block';
@@ -3772,8 +3775,8 @@
             const overlay = document.createElement('div');
             overlay.id = 'privacy-viewer';
             overlay.className = 'qr-overlay';
-            const src = 'privacy.html' + (guid ? `?guid=${encodeURIComponent(guid)}` : '');
-            overlay.innerHTML = `<div class="qr-modal" style="width:90%;height:90%;max-width:1000px;display:flex;flex-direction:column;"><iframe src="${src}" style="flex:1;border:none;border-radius:10px;"></iframe><button class="btn" onclick="document.getElementById('privacy-viewer').remove()">Close</button></div>`;
+            const route = 'app#privacy' + (guid ? `?guid=${encodeURIComponent(guid)}` : '');
+            overlay.innerHTML = `<div class="qr-modal" style="width:90%;height:90%;max-width:1000px;display:flex;flex-direction:column;"><iframe src="${route}" style="flex:1;border:none;border-radius:10px;"></iframe><button class="btn" onclick="document.getElementById('privacy-viewer').remove()">Close</button></div>`;
             overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
             document.body.appendChild(overlay);
         }
@@ -3788,7 +3791,7 @@
                         document.getElementById('location-loading').style.display = 'none';
                         document.getElementById('location-content').style.display = 'block';
                         const iframe = document.getElementById('text911Frame');
-                        iframe.src = 'text911.html';
+                        iframe.src = 'app#text911';
                     },
                     (error) => {
                         document.getElementById('location-loading').style.display = 'none';

--- a/modules.html
+++ b/modules.html
@@ -331,7 +331,7 @@
     <div class="container">
         <header>
             <div class="header-nav">
-                <a href="index.html" class="back-link">← Dashboard</a>
+                <a href="#" class="back-link" onclick="router.go('app#index'); return false;">← Dashboard</a>
             </div>
             <h1>Settings <span class="save-indicator" id="saveIndicator">Saved</span></h1>
         </header>

--- a/notes.html
+++ b/notes.html
@@ -72,7 +72,7 @@
 <body>
     <div class="header">
         <div class="header-left">
-            <button class="back-btn" onclick="window.location='index.html'">← Back to Profile</button>
+            <button class="back-btn" onclick="router.go('app#index')">← Back to Profile</button>
             <h1 class="page-title">📝 Notes</h1>
         </div>
         <button class="btn-primary" onclick="exportNotes()">Export All</button>
@@ -130,7 +130,7 @@
     <div id="successMessage" class="success-message">✓ Note saved successfully</div>
     <script>
         const password = sessionStorage.getItem('ownerPassword');
-        if(!password){ alert('Please login first'); window.location='index.html'; }
+        if(!password){ alert('Please login first'); router.go('app#index'); }
         const STORAGE_KEY = 'ikeyNotesEnc';
         let notes = [];
         let selectedCategory = null;


### PR DESCRIPTION
## Summary
- Replace hardcoded HTML navigation with `router.go` calls for internal pages
- Add breadcrumb support for external resources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b08c6469e0833296ce197db836e7c6