### PR TITLE
Namespace CSS animations and add duplicate ID check

### DIFF
--- a/app.bundle.js
+++ b/app.bundle.js
@@ -919,7 +919,7 @@
                         <span class="section-icon">${icon}</span>
                         <h3>${title}</h3>
                         <div class="mini-progress">
-                            <div class="progress-bar" style="width: ${percent}%"></div>
+                            <div class="home-progress__bar" style="width: ${percent}%"></div>
                         </div>
                     </div>
                     <div class="section-fields">

--- a/check-duplicate-ids.js
+++ b/check-duplicate-ids.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+function getHtmlFiles(dir) {
+  return fs.readdirSync(dir).filter(f => f.endsWith('.html'));
+}
+
+const files = process.argv.slice(2);
+const targets = files.length ? files : getHtmlFiles(process.cwd());
+let hasDupes = false;
+
+for (const file of targets) {
+  const content = fs.readFileSync(path.join(process.cwd(), file), 'utf8');
+  const ids = new Set();
+  const regex = /id="([^"]+)"/g;
+  let match;
+  while ((match = regex.exec(content))) {
+    const id = match[1];
+    if (id.includes('$')) continue; // ignore template placeholders
+    if (ids.has(id)) {
+      console.error(`Duplicate id "${id}" found in ${file}`);
+      hasDupes = true;
+    } else {
+      ids.add(id);
+    }
+  }
+}
+
+if (hasDupes) {
+  process.exit(1);
+} else {
+  console.log('No duplicate IDs found.');
+}

--- a/health-records.html
+++ b/health-records.html
@@ -145,15 +145,15 @@
             background: #dc2626;
             color: white;
             font-weight: 600;
-            animation: pulse 2s infinite;
+            animation: ehr-pulse 2s infinite;
         }
-        
+
         .btn-save.saved {
             background: #22c55e;
             animation: none;
         }
-        
-        @keyframes pulse {
+
+        @keyframes ehr-pulse {
             0% { opacity: 1; }
             50% { opacity: 0.8; }
             100% { opacity: 1; }
@@ -835,9 +835,9 @@
             position: relative;
         }
         .session-timer.pulse {
-            animation: pulse 1s infinite;
+            animation: ehr-timer-pulse 1s infinite;
         }
-        @keyframes pulse {
+        @keyframes ehr-timer-pulse {
             0% { box-shadow: 0 0 0 0 rgba(255, 152, 0, 0.7); }
             70% { box-shadow: 0 0 0 10px rgba(255, 152, 0, 0); }
             100% { box-shadow: 0 0 0 0 rgba(255, 152, 0, 0); }

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
             overflow: hidden;
         }
 
-        .progress-bar {
+        .home-progress__bar {
             height: 100%;
             width: 0;
             background: linear-gradient(90deg, #667eea, #764ba2);
@@ -596,10 +596,10 @@
             color: #856404;
             border: 2px solid #ffc107;
             font-weight: 600;
-            animation: pulse 2s infinite;
+            animation: home-status-pulse 2s infinite;
         }
 
-        @keyframes pulse {
+        @keyframes home-status-pulse {
             0% { opacity: 1; }
             50% { opacity: 0.8; }
             100% { opacity: 1; }
@@ -725,7 +725,7 @@
             font-style: italic;
         }
 
-        .progress-bar {
+        .home-progress__bar {
             height: 6px;
             background: #e9ecef;
             margin: 0 30px 20px;
@@ -1029,7 +1029,7 @@
             border-radius: 2px;
             position: relative;
         }
-        .mini-progress .progress-bar {
+        .mini-progress .home-progress__bar {
             height: 100%;
             background: var(--primary);
             border-radius: 2px;
@@ -1242,9 +1242,9 @@
             position: relative;
         }
         .session-timer.pulse {
-            animation: pulse 1s infinite;
+            animation: home-timer-pulse 1s infinite;
         }
-        @keyframes pulse {
+        @keyframes home-timer-pulse {
             0% { box-shadow: 0 0 0 0 rgba(255, 152, 0, 0.7); }
             70% { box-shadow: 0 0 0 10px rgba(255, 152, 0, 0); }
             100% { box-shadow: 0 0 0 0 rgba(255, 152, 0, 0); }
@@ -1551,13 +1551,9 @@
                     <p>Getting your location...</p>
                 </div>
                 <div id="location-content" style="display:none;">
-                    <iframe id="text911Frame" style="border:none;width:100%;height:1px;" scrolling="no"></iframe>
+                    <iframe id="text911Frame" style="border:none;width:100%;height:600px;" scrolling="no"></iframe>
                 </div>
             </div>
-        <div id="location-content" style="display:none;">
-            <iframe id="text911Frame" style="border:none;width:100%;height:600px;"></iframe>
-        </div>
-        </div>
         </div>
     </div>
     <!-- Notes modal script removed -->

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "ikey",
+  "version": "1.0.0",
+  "scripts": {
+    "lint:ids": "node check-duplicate-ids.js"
+  }
+}

--- a/text911.html
+++ b/text911.html
@@ -251,9 +251,9 @@
             height: 8px;
             border-radius: 50%;
             background: #10b981;
-            animation: pulse 2s infinite;
+            animation: text911-pulse 2s infinite;
         }
-        @keyframes pulse {
+        @keyframes text911-pulse {
             0%,100%{opacity:1;}
             50%{opacity:0.5;}
         }


### PR DESCRIPTION
## Summary
- remove duplicate `#location-content` section and ensure 911 frame renders once
- namespace progress bar and pulse keyframes per module to avoid clashes
- add Node-based lint to fail on duplicate element IDs

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0b5e5ab288332a961a82b07e4986e