### PR TITLE
Add baseline language menu and async translation loading

### DIFF
--- a/app.html
+++ b/app.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>iKey App</title>
-  <style>
+    <title>iKey App</title>
+    <style>
     :root {
       --top-bar-height: 0px;
     }
@@ -12,41 +12,89 @@
       margin: 0;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     }
-    .top-bar {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      background: white;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 10px 20px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-      z-index: 1000;
-    }
-    main {
-      padding-top: var(--top-bar-height);
-      scroll-margin-top: var(--top-bar-height);
-    }
-  </style>
-</head>
-<body>
-  <div class="top-bar">
-    <div class="logo">iKey</div>
-  </div>
-  <main class="main">
-    <h1>Welcome to iKey</h1>
-    <p>Your secure information vault.</p>
-  </main>
+      .top-bar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        background: white;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 20px;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+        z-index: 1000;
+      }
+      .lang-select {
+        position: relative;
+      }
+      .lang-button {
+        background: white;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        padding: 6px 10px;
+        cursor: pointer;
+        font-size: 0.875rem;
+        direction: ltr;
+      }
+      .lang-dropdown {
+        position: absolute;
+        right: 0;
+        top: 100%;
+        background: white;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        margin-top: 4px;
+        box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+        display: none;
+        max-height: 300px;
+        overflow-y: auto;
+        min-width: 160px;
+        z-index: 1000;
+        direction: ltr;
+        text-align: left;
+      }
+      .lang-option {
+        padding: 8px 12px;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .lang-option:hover,
+      .lang-option.active {
+        background: #f0f0f0;
+      }
+      main {
+        padding-top: var(--top-bar-height);
+        scroll-margin-top: var(--top-bar-height);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="top-bar">
+      <div class="logo">iKey</div>
+      <div class="lang-select">
+        <button class="lang-button" onclick="toggleLangDropdown()"><span id="current-language">EN</span> ▼</button>
+        <div class="lang-dropdown">
+          <div class="lang-option" data-lang="en" dir="auto">EN English</div>
+          <div class="lang-option" data-lang="es" dir="auto">ES Español</div>
+          <div class="lang-option" data-lang="ar" dir="auto">AR العربية</div>
+          <div class="lang-option" data-lang="ku" dir="auto">KU کوردی</div>
+        </div>
+      </div>
+    </div>
+    <main class="main">
+      <h1>Welcome to iKey</h1>
+      <p>Your secure information vault.</p>
+    </main>
   <script>
     function updateTopBarOffset() {
       const topBar = document.querySelector('.top-bar');
       const height = topBar ? topBar.offsetHeight : 0;
       document.documentElement.style.setProperty('--top-bar-height', height + 'px');
     }
-    window.addEventListener('load', updateTopBarOffset);
-    window.addEventListener('resize', updateTopBarOffset);
-  </script>
-</body>
+      window.addEventListener('load', updateTopBarOffset);
+      window.addEventListener('resize', updateTopBarOffset);
+    </script>
+    <script src="app.bundle.js"></script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1466,7 +1466,12 @@
             </div>
             <div class="lang-select">
                 <button class="lang-button" onclick="toggleLangDropdown()"><span id="current-language">EN</span> ▼</button>
-                <div class="lang-dropdown"></div>
+                <div class="lang-dropdown">
+                    <div class="lang-option" data-lang="en" dir="auto">EN English</div>
+                    <div class="lang-option" data-lang="es" dir="auto">ES Español</div>
+                    <div class="lang-option" data-lang="ar" dir="auto">AR العربية</div>
+                    <div class="lang-option" data-lang="ku" dir="auto">KU کوردی</div>
+                </div>
             </div>
             <button class="home-btn" onclick="window.location='index.html'">Home</button>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>


### PR DESCRIPTION
## Summary
- Pre-render baseline EN/ES/AR/KU options in index.html and app.html so language menu is always visible
- Load translations.json asynchronously and merge new languages into existing dropdown
- Attach handlers for static language options and skip clearing menu when translations are missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5e6177c833299bbe055c5a30557