### PR TITLE
Improve mobile grid and touch interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         
         .options-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
             gap: 30px;
             margin-bottom: 40px;
         }
@@ -174,7 +174,7 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             color: white;
             border: none;
-            padding: 12px 30px;
+            padding: 14px 30px;
             border-radius: 8px;
             font-size: 16px;
             font-weight: 600;
@@ -188,6 +188,14 @@
         .action-button:hover {
             transform: scale(1.05);
             box-shadow: 0 5px 20px rgba(102, 126, 234, 0.3);
+        }
+
+        @media (hover: none) {
+            .option-card:hover,
+            .action-button:hover {
+                transform: none;
+                box-shadow: none;
+            }
         }
         
         .recommended-badge {


### PR DESCRIPTION
## Summary
- Narrow options grid to use `minmax(280px, 1fr)` for better fit on small screens
- Increase button padding for 44px tap targets and remove hover effects on touch devices

## Testing
- `npm init -y && npm install puppeteer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5e72334833288830c2220d0dbc8