### PR TITLE
Use router navigation instead of index.html links

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Bulk QR Generation - Coming Soon</title>
+  <script src="router.js"></script>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
@@ -52,7 +53,7 @@
 <body>
   <div class="top-bar">
     <div class="logo"><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo"><span>iKey</span></div>
-    <div class="controls"><button onclick="window.location='index.html'">Home</button></div>
+    <div class="controls"><button onclick="router.go('home')">Home</button></div>
   </div>
   <div class="container">
     <h1>Bulk QR Generation</h1>

--- a/dashboard.html
+++ b/dashboard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Emergency Profile - Sarah Chen</title>
     <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon.ico">
+    <script src="router.js"></script>
     <style>
         * {
             margin: 0;
@@ -345,9 +346,9 @@
 <body>
     <header class="header">
         <nav class="nav">
-            <a href="index.html" class="logo"><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo"></a>
+            <a href="#" class="logo" onclick="router.go('home')"><img src="https://storage.googleapis.com/art_homelessness/1.png" alt="iKey logo"></a>
             <div class="nav-center">
-                <a href="index.html" class="nav-link active">Dashboard</a>
+                <a href="#" class="nav-link active" onclick="router.go('home')">Dashboard</a>
                 <a href="#" class="nav-link">Emergency View</a>
                 <a href="#" class="nav-link">🩺 EHR</a>
                 <a href="#" class="nav-link">Settings</a>

--- a/health-records.html
+++ b/health-records.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Electronic Health Records - Secure Medical Record</title>
     <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon.ico">
+    <script src="router.js"></script>
     <style>
         @page {
             size: letter;
@@ -1627,7 +1628,7 @@
                     if (window.parent && window.parent !== window) {
                         window.parent.postMessage({ type: 'closeHealthRecords' }, '*');
                     } else {
-                        window.location.href = 'index.html';
+                        router.go('home');
                     }
                 });
                 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>iKey - Secure Personal Information Vault</title>
+    <script src="router.js"></script>
     <style>
         * {
             margin: 0;
@@ -249,7 +250,7 @@
         </div>
         
         <div class="options-grid">
-            <div class="option-card" onclick="location.hash='app#create'">
+            <div class="option-card" onclick="router.go('app#create')">
                 <div class="recommended-badge">Recommended</div>
                 <div class="icon">👤</div>
                 <h2 class="option-title">Personal QR Code</h2>
@@ -269,7 +270,7 @@
                 </button>
             </div>
             
-            <div class="option-card" onclick="location.hash='app#bulk'">
+            <div class="option-card" onclick="router.go('app#bulk')">
                 <div class="icon">📋</div>
                 <h2 class="option-title">Bulk QR Generation</h2>
                 <p class="option-description">
@@ -1468,7 +1469,7 @@
                 <button class="lang-button" onclick="toggleLangDropdown()"><span id="current-language">EN</span> ▼</button>
                 <div class="lang-dropdown"></div>
             </div>
-            <button class="home-btn" onclick="window.location='index.html'">Home</button>
+            <button class="home-btn" onclick="router.go('home')">Home</button>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>
             <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
             <button class="notes-tab-btn" style="display:none;" onclick="window.location='notes.html'">📝 Notes</button>

--- a/modules.html
+++ b/modules.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Profile Settings - Modules</title>
     <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon.ico">
+    <script src="router.js"></script>
     <style>
         * {
             margin: 0;
@@ -331,7 +332,7 @@
     <div class="container">
         <header>
             <div class="header-nav">
-                <a href="index.html" class="back-link">← Dashboard</a>
+                <a href="#" class="back-link" onclick="router.go('home')">← Dashboard</a>
             </div>
             <h1>Settings <span class="save-indicator" id="saveIndicator">Saved</span></h1>
         </header>

--- a/notes.html
+++ b/notes.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>iKey - Notes</title>
     <link rel="icon" href="https://storage.googleapis.com/art_homelessness/favicon.ico">
+    <script src="router.js"></script>
     <style>
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; background:#f5f6fa; color:#333; line-height:1.6; }
@@ -72,7 +73,7 @@
 <body>
     <div class="header">
         <div class="header-left">
-            <button class="back-btn" onclick="window.location='index.html'">← Back to Profile</button>
+            <button class="back-btn" onclick="router.go('home')">← Back to Profile</button>
             <h1 class="page-title">📝 Notes</h1>
         </div>
         <button class="btn-primary" onclick="exportNotes()">Export All</button>
@@ -130,7 +131,7 @@
     <div id="successMessage" class="success-message">✓ Note saved successfully</div>
     <script>
         const password = sessionStorage.getItem('ownerPassword');
-        if(!password){ alert('Please login first'); window.location='index.html'; }
+        if(!password){ alert('Please login first'); router.go('home'); }
         const STORAGE_KEY = 'ikeyNotesEnc';
         let notes = [];
         let selectedCategory = null;

--- a/router.js
+++ b/router.js
@@ -1,0 +1,32 @@
+(function(){
+  function isHome(){
+    const path = location.pathname;
+    return path.endsWith('/') || path.endsWith('/index.html');
+  }
+  window.router = {
+    go(target){
+      if(target === 'home'){
+        if(isHome()){
+          location.hash = '';
+        } else {
+          location.href = 'index.html';
+        }
+        return;
+      }
+      if(target.startsWith('app')){
+        if(isHome()){
+          location.hash = target;
+        } else {
+          location.href = 'index.html#' + target;
+        }
+        return;
+      }
+      if(/^https?:/i.test(target)){
+        history.pushState(null, '', location.href);
+        location.href = target;
+        return;
+      }
+      location.href = target;
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- add a small router utility to handle hash navigation and external URLs
- replace direct `index.html` links with `router.go(...)`
- update marketing CTAs to rely on router-driven hash changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5e7d82483328dad6233df36079a