### PR TITLE
Use permission gate and frame manager for location features

### DIFF
--- a/app.bundle.js
+++ b/app.bundle.js
@@ -2190,12 +2190,7 @@
          let location911Enabled = false;
 
         window.addEventListener('message', function(e) {
-            if (e.data && e.data.type === 'text911Height') {
-                const frame = document.getElementById('text911Frame');
-                if (frame) {
-                    frame.style.height = e.data.height + 'px';
-                }
-            } else if (e.data && e.data.type === 'closeHealthRecords') {
+            if (e.data && e.data.type === 'closeHealthRecords') {
                 showQRTab();
             }
         });
@@ -2289,6 +2284,14 @@
             try {
                 document.getElementById('location-permission-prompt').style.display = 'none';
                 document.getElementById('location-loading').style.display = 'block';
+                const gate = await permissionGate.geolocation();
+                if (!gate.ok) {
+                    document.getElementById('location-loading').style.display = 'none';
+                    document.getElementById('location-permission-prompt').style.display = 'block';
+                    (window.notifier && window.notifier.error ? window.notifier.error(gate.reason)
+                        : (window.showToast ? window.showToast(gate.reason) : alert(gate.reason)));
+                    return;
+                }
                 await navigator.geolocation.getCurrentPosition(
                     (position) => {
                         location911Enabled = true;
@@ -2300,14 +2303,18 @@
                     (error) => {
                         document.getElementById('location-loading').style.display = 'none';
                         document.getElementById('location-permission-prompt').style.display = 'block';
-                        alert('Location access is required for 911 emergency features. Please enable location in your browser settings.');
+                        const msg = 'Location access is required for 911 emergency features. Please enable location in your browser settings.';
+                        (window.notifier && window.notifier.error ? window.notifier.error(msg)
+                            : (window.showToast ? window.showToast(msg) : alert(msg)));
                     },
                     { enableHighAccuracy: true }
                 );
             } catch (error) {
                 document.getElementById('location-loading').style.display = 'none';
                 document.getElementById('location-permission-prompt').style.display = 'block';
-                alert('Unable to access location. Please check your browser settings.');
+                const msg = 'Unable to access location. Please check your browser settings.';
+                (window.notifier && window.notifier.error ? window.notifier.error(msg)
+                    : (window.showToast ? window.showToast(msg) : alert(msg)));
             }
         }
 

--- a/app.js
+++ b/app.js
@@ -385,15 +385,19 @@ document.addEventListener("DOMContentLoaded", () => {
         return;
       }
 
-      if (!("geolocation" in navigator)) {
-        alert("Geolocation not available on this device/browser.");
+      const gate = await permissionGate.geolocation();
+      if (!gate.ok) {
+        (window.notifier && window.notifier.error ? window.notifier.error(gate.reason)
+          : (window.showToast ? window.showToast(gate.reason) : alert(gate.reason)));
         return;
       }
       navigator.geolocation.getCurrentPosition(async pos => {
         const lat = round6(pos.coords.latitude);
         const lng = round6(pos.coords.longitude);
         if (!validLatLng(lat, lng)) {
-          alert("Got invalid coordinates from the device.");
+          const msg = "Got invalid coordinates from the device.";
+          (window.notifier && window.notifier.error ? window.notifier.error(msg)
+            : (window.showToast ? window.showToast(msg) : alert(msg)));
           return;
         }
         const place = {
@@ -408,7 +412,9 @@ document.addEventListener("DOMContentLoaded", () => {
         await savePlaceNote(place);
         reset();
       }, err => {
-        alert("Couldn't get your location. You can switch to 'Enter coordinates'.");
+        const msg = "Couldn't get your location. You can switch to 'Enter coordinates'.";
+        (window.notifier && window.notifier.error ? window.notifier.error(msg)
+          : (window.showToast ? window.showToast(msg) : alert(msg)));
         console.error(err);
       }, { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 });
       return;

--- a/frame-manager.js
+++ b/frame-manager.js
@@ -1,0 +1,24 @@
+(function(){
+  class FrameManager {
+    static initParent(){
+      window.addEventListener('message', e => {
+        const d = e.data;
+        if(!d || d.type !== 'frame-resize') return;
+        const frame = document.getElementById(d.id);
+        if(frame) frame.style.height = d.height + 'px';
+      });
+    }
+    static initChild(id){
+      function send(){
+        if(window.parent){
+          const h = document.body.scrollHeight;
+          window.parent.postMessage({type:'frame-resize', id, height:h}, '*');
+        }
+      }
+      window.addEventListener('load', send);
+      window.addEventListener('resize', send);
+      FrameManager.sendHeight = send;
+    }
+  }
+  window.FrameManager = FrameManager;
+})();

--- a/index.html
+++ b/index.html
@@ -348,6 +348,7 @@
             const scripts = [
                 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js',
                 'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js',
+                'permission-gate.js',
                 'app.js',
                 'medication.js',
                 'text-size.js',
@@ -1561,6 +1562,10 @@
         </div>
     </div>
     <!-- Notes modal script removed -->
+    <script src="frame-manager.js"></script>
+    <script>
+      FrameManager.initParent();
+    </script>
     <script src="session.js"></script>
 </body>
 </html>

--- a/notes.html
+++ b/notes.html
@@ -67,6 +67,7 @@
         .success-message { position:fixed; top:70px; right:20px; background:#28a745; color:white; padding:12px 20px; border-radius:8px; box-shadow:0 4px 12px rgba(40,167,69,0.2); display:none; z-index:1000; animation:slideIn .3s ease; }
         @keyframes slideIn { from{transform:translateX(400px);} to{transform:translateX(0);} }
     </style>
+    <script src="permission-gate.js"></script>
     <script src="app.js"></script>
 </head>
 <body>
@@ -154,17 +155,28 @@
             displayNotes();
         }
 
-        function toggleLocation(){
+        async function toggleLocation(){
             const toggle = document.getElementById('locationToggle');
             const status = document.getElementById('locationStatus');
             if(toggle.checked){
-                if(navigator.geolocation){
-                    navigator.geolocation.getCurrentPosition(pos=>{
-                        currentLocation={lat:pos.coords.latitude,lng:pos.coords.longitude};
-                        status.className='location-status active';
-                        status.textContent='✓ Location captured';
-                    },()=>{toggle.checked=false; currentLocation=null; alert('Location access denied');});
-                } else { toggle.checked=false; alert('Location services not available.'); }
+                const gate = await permissionGate.geolocation();
+                if(!gate.ok){
+                    toggle.checked=false;
+                    currentLocation=null;
+                    (window.notifier && window.notifier.error ? window.notifier.error(gate.reason)
+                        : (window.showToast ? window.showToast(gate.reason) : alert(gate.reason)));
+                    return;
+                }
+                navigator.geolocation.getCurrentPosition(pos=>{
+                    currentLocation={lat:pos.coords.latitude,lng:pos.coords.longitude};
+                    status.className='location-status active';
+                    status.textContent='✓ Location captured';
+                },()=>{
+                    toggle.checked=false; currentLocation=null;
+                    const msg='Location access denied';
+                    (window.notifier && window.notifier.error ? window.notifier.error(msg)
+                        : (window.showToast ? window.showToast(msg) : alert(msg)));
+                });
             } else { currentLocation=null; status.className='location-status'; }
         }
 

--- a/permission-gate.js
+++ b/permission-gate.js
@@ -1,0 +1,23 @@
+(function(){
+  async function geolocation(){
+    if(!('geolocation' in navigator)){
+      return {ok:false, reason:'Geolocation not supported on this device/browser.'};
+    }
+    const insecure = location.protocol !== 'https:' && location.hostname !== 'localhost';
+    if(insecure){
+      return {ok:false, reason:'Geolocation requires a secure connection (HTTPS or localhost).'};
+    }
+    if(navigator.permissions && navigator.permissions.query){
+      try{
+        const status = await navigator.permissions.query({name:'geolocation'});
+        if(status.state === 'denied'){
+          return {ok:false, reason:'Location permission denied.'};
+        }
+      }catch(e){
+        // ignore errors and assume prompt
+      }
+    }
+    return {ok:true};
+  }
+  window.permissionGate = { geolocation };
+})();

--- a/text911.html
+++ b/text911.html
@@ -263,6 +263,8 @@
             body{padding:0;}
         }
     </style>
+    <script src="permission-gate.js"></script>
+    <script src="frame-manager.js"></script>
     <script src="text-size.js"></script>
 </head>
 <body>
@@ -330,14 +332,7 @@
         };
         const textingDataPromise=fetch('911-texting.json').then(r=>r.json());
 
-        function sendHeight(){
-            if(window.parent){
-                const h=document.body.scrollHeight;
-                window.parent.postMessage({type:'text911Height',height:h},'*');
-            }
-        }
-        window.addEventListener('load',sendHeight);
-        window.addEventListener('resize',sendHeight);
+        FrameManager.initChild('text911Frame');
 
         function encodePlusCode(latitude,longitude){
             latitude=Math.max(-90,Math.min(90,latitude));
@@ -362,10 +357,10 @@
             document.getElementById('loading').style.display='none';
             document.getElementById('content').style.display='block';
             document.getElementById('error').style.display='none';
-            sendHeight();
+            FrameManager.sendHeight();
         }
-        function showError(error){let message='';switch(error.code){case error.PERMISSION_DENIED:message="Location access denied. Please enable it and refresh.";break;case error.POSITION_UNAVAILABLE:message="Location unavailable. Please try again.";break;case error.TIMEOUT:message="Location request timed out. Please refresh.";break;default:message="Unable to get location. Please refresh.";}document.getElementById('errorMessage').textContent=message;document.getElementById('loading').style.display='none';document.getElementById('content').style.display='none';document.getElementById('emergencyButtons').style.display='none';document.getElementById('error').style.display='block';sendHeight();}
-        function getLocation(){if(navigator.geolocation){navigator.geolocation.getCurrentPosition(updateDisplay,showError,{enableHighAccuracy:true,timeout:15000,maximumAge:0});navigator.geolocation.watchPosition(updateDisplay,()=>{},{enableHighAccuracy:true,maximumAge:10000});}else{showError({code:0,message:"Geolocation not supported"});}}
+        function showError(error){let message='';switch(error.code){case error.PERMISSION_DENIED:message="Location access denied. Please enable it and refresh.";break;case error.POSITION_UNAVAILABLE:message="Location unavailable. Please try again.";break;case error.TIMEOUT:message="Location request timed out. Please refresh.";break;default:message=error.message||"Unable to get location. Please refresh.";}document.getElementById('errorMessage').textContent=message;document.getElementById('loading').style.display='none';document.getElementById('content').style.display='none';document.getElementById('emergencyButtons').style.display='none';document.getElementById('error').style.display='block';showToast(message);FrameManager.sendHeight();}
+        async function getLocation(){const gate=await permissionGate.geolocation();if(!gate.ok){showError({code:1,message:gate.reason});return;}navigator.geolocation.getCurrentPosition(updateDisplay,showError,{enableHighAccuracy:true,timeout:15000,maximumAge:0});navigator.geolocation.watchPosition(updateDisplay,()=>{},{enableHighAccuracy:true,maximumAge:10000});}
         window.onload=function(){getLocation();};
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add reusable geolocation permission gate returning `{ok, reason}`
- centralize iframe resizing with a shared `FrameManager`
- show notifier-based errors when location access is unavailable

## Testing
- `node --check permission-gate.js frame-manager.js app.js app.bundle.js`


------
https://chatgpt.com/codex/tasks/task_b_68b0b5ed104083329e6eae4c27487cc5