### PR TITLE
feat: guard health records module and track script loading

### DIFF
--- a/app.bundle.js
+++ b/app.bundle.js
@@ -877,7 +877,7 @@
 
                         ${renderSectionCard('Electronic Health Records', '🏥', sections.vault, [
                             { label: 'Records', value: fields.vault.records + ' documents' }
-                        ], 'showHealthRecordsTab()', 'vault')}
+                        ], 'showHealthRecordsTabSafe()', 'vault')}
                         <div class="emergency-card">
                             <h3>🚨 Emergency Services</h3>
                             <p style="margin-bottom:8px;">Tap to open</p>
@@ -911,7 +911,7 @@
             const percent = Math.round((progress.filled / progress.total) * 100);
             const clickAttr = onClick ? ` onclick="${onClick}" style="cursor:pointer"` : '';
             const actionButton = sectionKey === 'vault'
-                ? `<button class="edit-section-btn" onclick="event.stopPropagation(); showHealthRecordsTab()">Open</button>`
+                ? `<button class="edit-section-btn" onclick="event.stopPropagation(); showHealthRecordsTabSafe()">Open</button>`
                 : `<button class="edit-section-btn" onclick="event.stopPropagation(); openEditModal('${sectionKey}')">Edit</button>`;
             return `
                 <div class="section-card ${percent === 100 ? 'complete' : ''}"${clickAttr}>
@@ -1488,6 +1488,10 @@
                 }
 
                 alert('Store this password somewhere safe. Without it, you cannot archive new data or modify the protected content.');
+
+                if (!(await ensureHealthApp())) {
+                    throw new Error('Health records module not loaded');
+                }
 
                 // Generate identifiers and keys
                 currentGUID = generateGUID();
@@ -2219,6 +2223,10 @@
         }
 
        async function showHealthRecordsTab() {
+            if (!(await ensureHealthApp())) {
+                alert('Health records module not loaded.');
+                return;
+            }
             if (!ownerPassword) {
                 await ownerLogin();
                 if (!ownerPassword) return;

--- a/index.html
+++ b/index.html
@@ -343,8 +343,23 @@
             });
         });
 
+        window.modulePromises = {};
+
+        function showModuleError(src) {
+            let err = document.getElementById('module-error');
+            if (!err) {
+                err = document.createElement('div');
+                err.id = 'module-error';
+                err.style.color = 'red';
+                err.style.padding = '10px';
+                err.style.textAlign = 'center';
+                document.body.appendChild(err);
+            }
+            err.textContent = `⚠️ Failed to load required module: ${src}. Please refresh.`;
+        }
+
         function loadApp() {
-            if (window.appLoaded) return;
+            if (window.appLoaded) return window.allModulesPromise;
             const scripts = [
                 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js',
                 'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js',
@@ -353,16 +368,77 @@
                 'text-size.js',
                 'app.bundle.js'
             ];
+
             const loadNext = () => {
                 const src = scripts.shift();
                 if (!src) return;
-                const s = document.createElement('script');
-                s.src = src;
-                s.onload = loadNext;
-                document.body.appendChild(s);
+                window.modulePromises[src] = new Promise((resolve, reject) => {
+                    const s = document.createElement('script');
+                    s.src = src;
+                    s.onload = () => {
+                        window.loadedModules = window.loadedModules || {};
+                        window.loadedModules[src] = true;
+                        resolve();
+                        document.dispatchEvent(new CustomEvent('moduleLoaded', { detail: { src } }));
+                        loadNext();
+                    };
+                    s.onerror = () => {
+                        reject(new Error(`Failed to load ${src}`));
+                        showModuleError(src);
+                    };
+                    document.body.appendChild(s);
+                });
             };
+
             loadNext();
             window.appLoaded = true;
+            window.allModulesPromise = Promise.all(Object.values(window.modulePromises));
+            return window.allModulesPromise;
+        }
+
+        async function ensureHealthApp() {
+            if (window.healthApp) return true;
+            if (window.modulePromises['app.js']) {
+                try {
+                    await window.modulePromises['app.js'];
+                    return !!window.healthApp;
+                } catch {
+                    return false;
+                }
+            }
+            return false;
+        }
+
+        async function showHealthRecordsTabSafe() {
+            loadApp();
+            if (!(await ensureHealthApp())) {
+                let ph = document.getElementById('health-records-placeholder');
+                if (!ph) {
+                    ph = document.createElement('div');
+                    ph.id = 'health-records-placeholder';
+                    ph.style.padding = '20px';
+                    ph.style.textAlign = 'center';
+                    ph.textContent = 'Loading health records...';
+                    document.body.appendChild(ph);
+                } else {
+                    ph.textContent = 'Loading health records...';
+                }
+                try {
+                    await Promise.all([
+                        window.modulePromises['app.js'],
+                        window.modulePromises['app.bundle.js']
+                    ]);
+                } catch {
+                    ph.textContent = 'Unable to load health records.';
+                    return;
+                }
+                ph.remove();
+            }
+            if (typeof window.showHealthRecordsTab === 'function') {
+                window.showHealthRecordsTab();
+            } else {
+                alert('Health records module not available.');
+            }
         }
 
         function handleRoute() {
@@ -1470,7 +1546,7 @@
             </div>
             <button class="home-btn" onclick="window.location='index.html'">Home</button>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>
-            <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
+            <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTabSafe()">🩺 EHR</button>
             <button class="notes-tab-btn" style="display:none;" onclick="window.location='notes.html'">📝 Notes</button>
             <button class="resources-btn" onclick="showResourcesTab()">Resources</button>
             <button class="login-btn" onclick="ownerLogin()">Owner Login</button>


### PR DESCRIPTION
## Summary
- Track loading state for all scripts and surface errors if modules fail to load
- Add promise helpers and placeholder UI to wait for health records module
- Safely reference `window.healthApp` only after modules are ready

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5ea85c0833290a1889e3c04bf6a