### PR TITLE
refactor bootstrap initialization

### DIFF
--- a/app.bundle.js
+++ b/app.bundle.js
@@ -219,8 +219,7 @@
             }
         }
 
-        // Initialize on page load
-        window.addEventListener('DOMContentLoaded', async function() {
+        async function init() {
             if (Object.keys(translations).length === 0) {
                 try {
                     const response = await fetch('translations.json');
@@ -238,6 +237,9 @@
                 navigator.language.substring(0, 2) ||
                 'en';
             setLanguage(savedLang);
+
+            const logo = document.querySelector('.logo');
+            if (logo) logo.addEventListener('click', showQRTab);
 
             await parseAndDisplay();
 
@@ -258,7 +260,9 @@
                     sessionStorage.removeItem('ownerSessionExpires');
                 }
             }
-        });
+        }
+
+        window.appBundle = { init };
 
         async function loadEmergencyInfo(guid, key, permanentDataStr) {
             currentGUID = guid;
@@ -2310,11 +2314,6 @@
                 alert('Unable to access location. Please check your browser settings.');
             }
         }
-
-         // Add click handler for logo to return to QR
-         document.addEventListener('DOMContentLoaded', function() {
-             document.querySelector('.logo').addEventListener('click', showQRTab);
-         });
 
          // Allow closing dev tools
          document.addEventListener('keydown', function(e) {

--- a/app.js
+++ b/app.js
@@ -300,131 +300,133 @@ async function savePlaceNote(place) {
 }
 
 // ----------------- init -----------------
-document.addEventListener("DOMContentLoaded", () => {
-  const modeRadios = Array.from(document.querySelectorAll('input[name="placeMode"]'));
-  const manualRow = document.getElementById("manualCoords");
-  const latInput = document.getElementById("latInput");
-  const lngInput = document.getElementById("lngInput");
-  const titleInput = document.getElementById("titleInput");
-  const noteInput = document.getElementById("noteInput");
-  const saveBtn = document.getElementById("savePlaceBtn");
-  const locationToggle = document.getElementById("locationToggle");
-  const locationOptions = document.getElementById("locationOptions");
-  const categoryButtons = Array.from(document.querySelectorAll(".category-btn"));
-  let selectedCategory = null;
+window.appModule = {
+  init() {
+    const modeRadios = Array.from(document.querySelectorAll('input[name="placeMode"]'));
+    const manualRow = document.getElementById("manualCoords");
+    const latInput = document.getElementById("latInput");
+    const lngInput = document.getElementById("lngInput");
+    const titleInput = document.getElementById("titleInput");
+    const noteInput = document.getElementById("noteInput");
+    const saveBtn = document.getElementById("savePlaceBtn");
+    const locationToggle = document.getElementById("locationToggle");
+    const locationOptions = document.getElementById("locationOptions");
+    const categoryButtons = Array.from(document.querySelectorAll(".category-btn"));
+    let selectedCategory = null;
 
-  if (!saveBtn) return;
+    if (!saveBtn) return;
 
-  const updateModeUI = () => {
-    const mode = modeRadios.find(r => r.checked)?.value || "here";
-    manualRow.style.display = mode === "manual" ? "flex" : "none";
-  };
-  modeRadios.forEach(r => r.addEventListener("change", updateModeUI));
-  updateModeUI();
-
-  const updateLocationUI = () => {
-    locationOptions.style.display = locationToggle.checked ? "block" : "none";
-  };
-  locationToggle.addEventListener("change", updateLocationUI);
-  updateLocationUI();
-
-  categoryButtons.forEach(btn => {
-    btn.addEventListener("click", () => {
-      if (btn.classList.contains("selected")) {
-        btn.classList.remove("selected");
-        selectedCategory = null;
-      } else {
-        categoryButtons.forEach(b => b.classList.remove("selected"));
-        btn.classList.add("selected");
-        selectedCategory = btn.dataset.category;
-      }
-    });
-  });
-
-  try {
-    const cached = JSON.parse(localStorage.getItem("ikey.places.draft") || "[]");
-    if (Array.isArray(cached)) state.locations = cached;
-  } catch {}
-
-  saveBtn.addEventListener("click", async () => {
-    const title = (titleInput.value || "").trim();
-    const note = (noteInput.value || "").trim();
-    const includeLocation = locationToggle.checked;
-
-    const reset = () => {
-      titleInput.value = "";
-      noteInput.value = "";
-      latInput.value = "";
-      lngInput.value = "";
-      categoryButtons.forEach(b => b.classList.remove("selected"));
-      selectedCategory = null;
-      locationToggle.checked = false;
-      updateLocationUI();
-    };
-
-    if (includeLocation) {
+    const updateModeUI = () => {
       const mode = modeRadios.find(r => r.checked)?.value || "here";
-      if (mode === "manual") {
-        const lat = parseFloat(latInput.value);
-        const lng = parseFloat(lngInput.value);
-        if (!validLatLng(lat, lng)) {
-          alert("Please enter valid coordinates:\n-90 ≤ latitude ≤ 90\n-180 ≤ longitude ≤ 180");
-          return;
-        }
-        const place = {
-          id: uid(),
-          title,
-          note,
-          category: selectedCategory,
-          type: "coords",
-          coords: { lat: round6(lat), lng: round6(lng) },
-          createdAt: Date.now()
-        };
-        await savePlaceNote(place);
-        reset();
-        return;
-      }
-
-      if (!("geolocation" in navigator)) {
-        alert("Geolocation not available on this device/browser.");
-        return;
-      }
-      navigator.geolocation.getCurrentPosition(async pos => {
-        const lat = round6(pos.coords.latitude);
-        const lng = round6(pos.coords.longitude);
-        if (!validLatLng(lat, lng)) {
-          alert("Got invalid coordinates from the device.");
-          return;
-        }
-        const place = {
-          id: uid(),
-          title,
-          note,
-          category: selectedCategory,
-          type: "coords",
-          coords: { lat, lng },
-          createdAt: Date.now()
-        };
-        await savePlaceNote(place);
-        reset();
-      }, err => {
-        alert("Couldn't get your location. You can switch to 'Enter coordinates'.");
-        console.error(err);
-      }, { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 });
-      return;
-    }
-
-    const place = {
-      id: uid(),
-      title,
-      note,
-      category: selectedCategory,
-      type: "note",
-      createdAt: Date.now()
+      manualRow.style.display = mode === "manual" ? "flex" : "none";
     };
-    await savePlaceNote(place);
-    reset();
-  });
+    modeRadios.forEach(r => r.addEventListener("change", updateModeUI));
+    updateModeUI();
 
-  renderPlaces();
-});
+    const updateLocationUI = () => {
+      locationOptions.style.display = locationToggle.checked ? "block" : "none";
+    };
+    locationToggle.addEventListener("change", updateLocationUI);
+    updateLocationUI();
+
+    categoryButtons.forEach(btn => {
+      btn.addEventListener("click", () => {
+        if (btn.classList.contains("selected")) {
+          btn.classList.remove("selected");
+          selectedCategory = null;
+        } else {
+          categoryButtons.forEach(b => b.classList.remove("selected"));
+          btn.classList.add("selected");
+          selectedCategory = btn.dataset.category;
+        }
+      });
+    });
+
+    try {
+      const cached = JSON.parse(localStorage.getItem("ikey.places.draft") || "[]");
+      if (Array.isArray(cached)) state.locations = cached;
+    } catch {}
+
+    saveBtn.addEventListener("click", async () => {
+      const title = (titleInput.value || "").trim();
+      const note = (noteInput.value || "").trim();
+      const includeLocation = locationToggle.checked;
+
+      const reset = () => {
+        titleInput.value = "";
+        noteInput.value = "";
+        latInput.value = "";
+        lngInput.value = "";
+        categoryButtons.forEach(b => b.classList.remove("selected"));
+        selectedCategory = null;
+        locationToggle.checked = false;
+        updateLocationUI();
+      };
+
+      if (includeLocation) {
+        const mode = modeRadios.find(r => r.checked)?.value || "here";
+        if (mode === "manual") {
+          const lat = parseFloat(latInput.value);
+          const lng = parseFloat(lngInput.value);
+          if (!validLatLng(lat, lng)) {
+            alert("Please enter valid coordinates:\n-90 ≤ latitude ≤ 90\n-180 ≤ longitude ≤ 180");
+            return;
+          }
+          const place = {
+            id: uid(),
+            title,
+            note,
+            category: selectedCategory,
+            type: "coords",
+            coords: { lat: round6(lat), lng: round6(lng) },
+            createdAt: Date.now()
+          };
+          await savePlaceNote(place);
+          reset();
+          return;
+        }
+
+        if (!("geolocation" in navigator)) {
+          alert("Geolocation not available on this device/browser.");
+          return;
+        }
+        navigator.geolocation.getCurrentPosition(async pos => {
+          const lat = round6(pos.coords.latitude);
+          const lng = round6(pos.coords.longitude);
+          if (!validLatLng(lat, lng)) {
+            alert("Got invalid coordinates from the device.");
+            return;
+          }
+          const place = {
+            id: uid(),
+            title,
+            note,
+            category: selectedCategory,
+            type: "coords",
+            coords: { lat, lng },
+            createdAt: Date.now()
+          };
+          await savePlaceNote(place);
+          reset();
+        }, err => {
+          alert("Couldn't get your location. You can switch to 'Enter coordinates'.");
+          console.error(err);
+        }, { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 });
+        return;
+      }
+
+      const place = {
+        id: uid(),
+        title,
+        note,
+        category: selectedCategory,
+        type: "note",
+        createdAt: Date.now()
+      };
+      await savePlaceNote(place);
+      reset();
+    });
+
+    renderPlaces();
+  }
+};

--- a/boot.js
+++ b/boot.js
@@ -1,0 +1,37 @@
+let bootstrapped = false;
+
+function bootstrap() {
+  if (bootstrapped) {
+    console.warn('bootstrap() has already been called');
+    return;
+  }
+  bootstrapped = true;
+
+  // Initialize translations if app bundle provides handler
+  if (window.appBundle && typeof window.appBundle.init === 'function') {
+    window.appBundle.init();
+  }
+
+  // Initialize optional modules
+  const modules = [
+    window.indexPage,
+    window.appModule,
+    window.sessionModule,
+    window.notesPage,
+    window.privacyPage
+  ];
+  modules.forEach(mod => {
+    if (mod && typeof mod.init === 'function') {
+      mod.init();
+    }
+  });
+
+  // Bind global router
+  if (typeof window.handleRoute === 'function') {
+    window.addEventListener('hashchange', window.handleRoute);
+    window.handleRoute();
+  }
+}
+
+window.bootstrap = bootstrap;
+document.addEventListener('DOMContentLoaded', bootstrap);

--- a/index.html
+++ b/index.html
@@ -327,21 +327,23 @@
         </div>
     </div>
     <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const cards = document.querySelectorAll('.option-card');
-            cards.forEach((card, index) => {
-                setTimeout(() => {
-                    card.style.opacity = '0';
-                    card.style.transform = 'translateY(20px)';
-                    card.style.transition = 'all 0.5s ease';
-                    
+        window.indexPage = {
+            init() {
+                const cards = document.querySelectorAll('.option-card');
+                cards.forEach((card, index) => {
                     setTimeout(() => {
-                        card.style.opacity = '1';
-                        card.style.transform = 'translateY(0)';
-                    }, 100);
-                }, index * 100);
-            });
-        });
+                        card.style.opacity = '0';
+                        card.style.transform = 'translateY(20px)';
+                        card.style.transition = 'all 0.5s ease';
+
+                        setTimeout(() => {
+                            card.style.opacity = '1';
+                            card.style.transform = 'translateY(0)';
+                        }, 100);
+                    }, index * 100);
+                });
+            }
+        };
 
         function loadApp() {
             if (window.appLoaded) return;
@@ -371,9 +373,9 @@
             }
         }
 
-        window.addEventListener('hashchange', handleRoute);
-        handleRoute();
+        // router setup handled by bootstrap
     </script>
+    <script src="boot.js"></script>
         <style>
         @keyframes spin {
             0% { transform: rotate(0deg); }

--- a/notes.html
+++ b/notes.html
@@ -138,7 +138,7 @@
         let currentFilter = 'all';
         let editingId = null;
 
-        document.addEventListener('DOMContentLoaded', loadNotes);
+        window.notesPage = { init: loadNotes };
 
         async function loadNotes(){
             const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)||'[]');
@@ -239,5 +239,6 @@
         function showSuccessMessage(){ const msg=document.getElementById('successMessage'); msg.style.display='block'; setTimeout(()=>{msg.style.display='none';},3000); }
         function exportNotes(){ const dataStr=JSON.stringify(notes,null,2); const dataUri='data:application/json;charset=utf-8,'+encodeURIComponent(dataStr); const exportFileDefaultName='ikey-notes-'+new Date().toISOString().slice(0,10)+'.json'; const linkElement=document.createElement('a'); linkElement.setAttribute('href',dataUri); linkElement.setAttribute('download',exportFileDefaultName); linkElement.click(); }
     </script>
+    <script src="boot.js"></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -296,13 +296,14 @@
     document.getElementById('runBtn').addEventListener('click', runDemo);
     document.getElementById('recalc').addEventListener('click', updateBruteforceEstimate);
 
-    // Auto-run: detect GUID and fetch on load (no typing).
-    window.addEventListener('DOMContentLoaded', () => {
-      setGuidTag(getGuid());
-      updateBruteforceEstimate();
-      // Auto-run if we have a GUID ready:
-      if (getGuid()) runDemo();
-    });
+    window.privacyPage = {
+      init() {
+        setGuidTag(getGuid());
+        updateBruteforceEstimate();
+        if (getGuid()) runDemo();
+      }
+    };
   </script>
+  <script src="boot.js"></script>
 </body>
 </html>

--- a/session.js
+++ b/session.js
@@ -243,8 +243,10 @@ class SessionManager {
     }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    if (document.getElementById('session-timer')) {
-        window.sessionManager = new SessionManager();
+window.sessionModule = {
+    init() {
+        if (document.getElementById('session-timer')) {
+            window.sessionManager = new SessionManager();
+        }
     }
-});
+};


### PR DESCRIPTION
## Summary
- centralize app startup with new `bootstrap` that binds listeners, sets up translations, and starts routing
- expose `init()` from feature modules and pages instead of relying on `DOMContentLoaded`
- safeguard against multiple bootstrap calls to avoid duplicate listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5e99b888332b8341751e39e248e