### PR TITLE
Add client-side router for tab navigation

### DIFF
--- a/app-router.js
+++ b/app-router.js
@@ -1,0 +1,41 @@
+(function() {
+  const routes = {
+    'home': 'showQRTab',
+    'app#create': 'showQRTab',
+    'app#view': 'showQRTab',
+    'app#ehr': 'showHealthRecordsTab',
+    'app#resources': 'showResourcesTab',
+    'app#911': 'show911Tab'
+  };
+
+  function render(state) {
+    const handlerName = routes[state] || routes['home'];
+    const fn = window[handlerName];
+    if (typeof fn === 'function') {
+      fn();
+    }
+  }
+
+  function go(state) {
+    history.pushState({ state }, '', '#' + state);
+    if (typeof window.handleRoute === 'function') {
+      window.handleRoute();
+    } else {
+      render(state);
+    }
+  }
+
+  window.addEventListener('popstate', (e) => {
+    const state = (e.state && e.state.state) || location.hash.slice(1) || 'home';
+    if (typeof window.handleRoute === 'function') {
+      window.handleRoute();
+    } else {
+      render(state);
+    }
+  });
+
+  window.router = { render, go, routes };
+  const initial = location.hash.slice(1) || 'home';
+  history.replaceState({ state: initial }, '', '#' + initial);
+  render(initial);
+})();

--- a/app.bundle.js
+++ b/app.bundle.js
@@ -877,7 +877,7 @@
 
                         ${renderSectionCard('Electronic Health Records', '🏥', sections.vault, [
                             { label: 'Records', value: fields.vault.records + ' documents' }
-                        ], 'showHealthRecordsTab()', 'vault')}
+                        ], 'router.go(\'app#ehr\')', 'vault')}
                         <div class="emergency-card">
                             <h3>🚨 Emergency Services</h3>
                             <p style="margin-bottom:8px;">Tap to open</p>
@@ -911,7 +911,7 @@
             const percent = Math.round((progress.filled / progress.total) * 100);
             const clickAttr = onClick ? ` onclick="${onClick}" style="cursor:pointer"` : '';
             const actionButton = sectionKey === 'vault'
-                ? `<button class="edit-section-btn" onclick="event.stopPropagation(); showHealthRecordsTab()">Open</button>`
+                ? `<button class="edit-section-btn" onclick="event.stopPropagation(); router.go('app#ehr')">Open</button>`
                 : `<button class="edit-section-btn" onclick="event.stopPropagation(); openEditModal('${sectionKey}')">Edit</button>`;
             return `
                 <div class="section-card ${percent === 100 ? 'complete' : ''}"${clickAttr}>
@@ -2196,7 +2196,7 @@
                     frame.style.height = e.data.height + 'px';
                 }
             } else if (e.data && e.data.type === 'closeHealthRecords') {
-                showQRTab();
+                router.go('home');
             }
         });
 
@@ -2214,7 +2214,7 @@
 
         function confirmEmergencyAccess() {
             if (confirm('Open Emergency Services?')) {
-                show911Tab();
+                router.go('app#911');
             }
         }
 
@@ -2313,7 +2313,7 @@
 
          // Add click handler for logo to return to QR
          document.addEventListener('DOMContentLoaded', function() {
-             document.querySelector('.logo').addEventListener('click', showQRTab);
+             document.querySelector('.logo').addEventListener('click', () => router.go('home'));
          });
 
          // Allow closing dev tools

--- a/index.html
+++ b/index.html
@@ -238,6 +238,7 @@
             }
         }
     </style>
+    <script src="app-router.js"></script>
 </head>
 <body>
     <div class="container">
@@ -355,7 +356,10 @@
             ];
             const loadNext = () => {
                 const src = scripts.shift();
-                if (!src) return;
+                if (!src) {
+                    router.render(location.hash.slice(1) || 'home');
+                    return;
+                }
                 const s = document.createElement('script');
                 s.src = src;
                 s.onload = loadNext;
@@ -368,6 +372,9 @@
         function handleRoute() {
             if (location.hash.startsWith('#app')) {
                 loadApp();
+            }
+            if (window.router) {
+                router.render(location.hash.slice(1) || 'home');
             }
         }
 
@@ -1470,9 +1477,9 @@
             </div>
             <button class="home-btn" onclick="window.location='index.html'">Home</button>
             <button class="dashboard-btn" style="display:none;" onclick="showOwnerDashboard()">Dashboard</button>
-            <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
+            <button class="health-records-btn" style="display:none;" onclick="router.go('app#ehr')">🩺 EHR</button>
             <button class="notes-tab-btn" style="display:none;" onclick="window.location='notes.html'">📝 Notes</button>
-            <button class="resources-btn" onclick="showResourcesTab()">Resources</button>
+            <button class="resources-btn" onclick="router.go('app#resources')">Resources</button>
             <button class="login-btn" onclick="ownerLogin()">Owner Login</button>
             <div id="session-timer" class="session-timer">
                 <span id="session-countdown"></span>


### PR DESCRIPTION
## Summary
- Introduce lightweight router with state map and popstate handling for deep-link navigation
- Load app tabs via router.go instead of direct showTab functions
- Ensure dynamic script loader and controls use router for consistent history management

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5e8d1308332b55d0d387914a428