### PR TITLE
harden async usage and enable lint checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -389,24 +389,30 @@ document.addEventListener("DOMContentLoaded", () => {
         alert("Geolocation not available on this device/browser.");
         return;
       }
-      navigator.geolocation.getCurrentPosition(async pos => {
-        const lat = round6(pos.coords.latitude);
-        const lng = round6(pos.coords.longitude);
-        if (!validLatLng(lat, lng)) {
-          alert("Got invalid coordinates from the device.");
-          return;
-        }
-        const place = {
-          id: uid(),
-          title,
-          note,
-          category: selectedCategory,
-          type: "coords",
-          coords: { lat, lng },
-          createdAt: Date.now()
-        };
-        await savePlaceNote(place);
-        reset();
+      navigator.geolocation.getCurrentPosition(pos => {
+        (async () => {
+          try {
+            const lat = round6(pos.coords.latitude);
+            const lng = round6(pos.coords.longitude);
+            if (!validLatLng(lat, lng)) {
+              alert("Got invalid coordinates from the device.");
+              return;
+            }
+            const place = {
+              id: uid(),
+              title,
+              note,
+              category: selectedCategory,
+              type: "coords",
+              coords: { lat, lng },
+              createdAt: Date.now()
+            };
+            await savePlaceNote(place);
+            reset();
+          } catch (e) {
+            console.error(e);
+          }
+        })();
       }, err => {
         alert("Couldn't get your location. You can switch to 'Enter coordinates'.");
         console.error(err);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,13 @@
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+
+export default [
+  {
+    plugins: {
+      "@typescript-eslint": tsPlugin
+    },
+    rules: {
+      "require-await": "error",
+      "@typescript-eslint/no-misused-promises": "error"
+    }
+  }
+];

--- a/health-records.html
+++ b/health-records.html
@@ -1618,7 +1618,7 @@
                 });
                 
                 // Buttons
-                document.getElementById('saveBtn').addEventListener('click', () => this.saveData());
+                document.getElementById('saveBtn').addEventListener('click', () => { this.saveData().catch(console.error); });
                 document.getElementById('exportBtn').addEventListener('click', () => this.exportPDF());
                 document.getElementById('lockBtn').addEventListener('click', () => this.toggleLock());
                 document.getElementById('changePasswordBtn').addEventListener('click', () => this.changePassword());
@@ -1675,7 +1675,7 @@
                 document.addEventListener('keydown', (e) => {
                     if ((e.ctrlKey || e.metaKey) && e.key === 's') {
                         e.preventDefault();
-                        this.saveData();
+                        this.saveData().catch(console.error);
                     }
                 });
                 
@@ -1805,7 +1805,7 @@
                 this.saveReminderTimeout = setTimeout(() => {
                     if (this.hasUnsavedChanges) {
                         if (confirm('You have unsaved changes. Would you like to save now?')) {
-                            this.saveData();
+                            this.saveData().catch(console.error);
                         }
                     }
                 }, 5 * 60 * 1000);
@@ -1918,7 +1918,7 @@
                     this.timerInterval = setInterval(() => this.updateLockTimer(), 1000);
                 }
                 if (!this.loaded && this.sessionPassword) {
-                    this.loadArchiveData();
+                    this.loadArchiveData().catch(console.error);
                 }
             }
             
@@ -2077,7 +2077,7 @@
             unlockEmergencyPlans() {
                 if (!this.sessionPassword) {
                     alert('Please set a password first by saving to the archive');
-                    this.saveData();
+                    this.saveData().catch(console.error);
                     return;
                 }
                 

--- a/index.html
+++ b/index.html
@@ -1473,11 +1473,11 @@
             <button class="health-records-btn" style="display:none;" onclick="showHealthRecordsTab()">🩺 EHR</button>
             <button class="notes-tab-btn" style="display:none;" onclick="window.location='notes.html'">📝 Notes</button>
             <button class="resources-btn" onclick="showResourcesTab()">Resources</button>
-            <button class="login-btn" onclick="ownerLogin()">Owner Login</button>
+            <button class="login-btn" onclick="ownerLogin().catch(console.error)">Owner Login</button>
             <div id="session-timer" class="session-timer">
                 <span id="session-countdown"></span>
             </div>
-            <button class="logout-btn" style="display:none;" onclick="logoutOwner()">Logout</button>
+            <button class="logout-btn" style="display:none;" onclick="logoutOwner().catch(console.error)">Logout</button>
         </div>
     </div>
         <div id="qrTab">
@@ -1542,7 +1542,7 @@
                             <li>Only shared if YOU choose to text 911</li>
                         </ul>
                     </div>
-                    <button class="btn" onclick="requestLocationAndLoad911()">
+                    <button class="btn" onclick="requestLocationAndLoad911().catch(console.error)">
                         <span>Enable Location for Emergency Use</span>
                     </button>
                 </div>

--- a/notes.html
+++ b/notes.html
@@ -107,7 +107,7 @@
                     <label class="form-label">Details</label>
                     <textarea id="noteDetails" class="form-textarea" placeholder="Add important details"></textarea>
                 </div>
-                <button class="btn-primary" style="width:100%;" onclick="saveNote()" id="saveNoteBtn">Save Note</button>
+                <button class="btn-primary" style="width:100%;" onclick="saveNote().catch(console.error)" id="saveNoteBtn">Save Note</button>
             </div>
             <div class="notes-section">
                 <div class="section-header">
@@ -138,7 +138,7 @@
         let currentFilter = 'all';
         let editingId = null;
 
-        document.addEventListener('DOMContentLoaded', loadNotes);
+        document.addEventListener('DOMContentLoaded', () => { loadNotes().catch(console.error); });
 
         async function loadNotes(){
             const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)||'[]');

--- a/privacy.html
+++ b/privacy.html
@@ -293,7 +293,7 @@
     }
 
     // Wire up UI
-    document.getElementById('runBtn').addEventListener('click', runDemo);
+    document.getElementById('runBtn').addEventListener('click', () => { runDemo().catch(console.error); });
     document.getElementById('recalc').addEventListener('click', updateBruteforceEstimate);
 
     // Auto-run: detect GUID and fetch on load (no typing).
@@ -301,7 +301,7 @@
       setGuidTag(getGuid());
       updateBruteforceEstimate();
       // Auto-run if we have a GUID ready:
-      if (getGuid()) runDemo();
+      if (getGuid()) { runDemo().catch(console.error); }
     });
   </script>
 </body>

--- a/text911.html
+++ b/text911.html
@@ -365,7 +365,7 @@
             sendHeight();
         }
         function showError(error){let message='';switch(error.code){case error.PERMISSION_DENIED:message="Location access denied. Please enable it and refresh.";break;case error.POSITION_UNAVAILABLE:message="Location unavailable. Please try again.";break;case error.TIMEOUT:message="Location request timed out. Please refresh.";break;default:message="Unable to get location. Please refresh.";}document.getElementById('errorMessage').textContent=message;document.getElementById('loading').style.display='none';document.getElementById('content').style.display='none';document.getElementById('emergencyButtons').style.display='none';document.getElementById('error').style.display='block';sendHeight();}
-        function getLocation(){if(navigator.geolocation){navigator.geolocation.getCurrentPosition(updateDisplay,showError,{enableHighAccuracy:true,timeout:15000,maximumAge:0});navigator.geolocation.watchPosition(updateDisplay,()=>{},{enableHighAccuracy:true,maximumAge:10000});}else{showError({code:0,message:"Geolocation not supported"});}}
+        function getLocation(){if(navigator.geolocation){navigator.geolocation.getCurrentPosition(pos=>{updateDisplay(pos).catch(console.error);},showError,{enableHighAccuracy:true,timeout:15000,maximumAge:0});navigator.geolocation.watchPosition(pos=>{updateDisplay(pos).catch(console.error);},()=>{},{enableHighAccuracy:true,maximumAge:10000});}else{showError({code:0,message:"Geolocation not supported"});}}
         window.onload=function(){getLocation();};
     </script>
 </body>


### PR DESCRIPTION
## Summary
- ensure every `await` lives in an async function and wire callers to await or catch
- add lint config with `require-await` and `no-misused-promises` rules

## Testing
- `npx eslint app.bundle.js app.js health-records.html index.html notes.html privacy.html text911.html` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_b_68b0b5ed98248332b3d88e0c9f91b0b1