### PR TITLE
Add global QR modal styles for overlay and scroll lock

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,35 @@
                 grid-template-columns: 1fr;
             }
         }
+
+        /* Global QR modal styles */
+        .qr-overlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+        }
+
+        .qr-modal {
+            background: #fff;
+            border-radius: 8px;
+            max-width: 90%;
+            max-height: 90%;
+            overflow: auto;
+            padding: 20px;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+        }
+
+        body.qr-modal-open,
+        body:has(.qr-overlay) {
+            overflow: hidden;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add global `.qr-overlay` and `.qr-modal` styles to index.html with fixed positioning, backdrop, and flex centering.
- Prevent background scrolling when QR overlay is present.

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0b9ea32e083328f744670256f2368