### PR TITLE
Handle module load failure in loadAppAndRun

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,16 +528,25 @@
                 el.style.pointerEvents = 'none';
                 el.style.opacity = '0.6';
             }
-            loadApp().then(() => {
-                if (el) {
-                    el.textContent = el.dataset.originalText;
-                    el.style.pointerEvents = '';
-                    el.style.opacity = '';
-                }
-                if (typeof window[fnName] === 'function') {
-                    window[fnName]();
-                }
-            });
+            loadApp()
+                .then(() => {
+                    if (el) {
+                        el.textContent = el.dataset.originalText;
+                        el.style.pointerEvents = '';
+                        el.style.opacity = '';
+                    }
+                    if (typeof window[fnName] === 'function') {
+                        window[fnName]();
+                    }
+                })
+                .catch(() => {
+                    if (el) {
+                        el.textContent = el.dataset.originalText;
+                        el.style.pointerEvents = '';
+                        el.style.opacity = '';
+                    }
+                    alert('Failed to load the application module.');
+                });
             return false;
         }
 


### PR DESCRIPTION
## Summary
- restore button state when app module fails to load in `loadAppAndRun`
- alert user on module load failure

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0be6dea848332a46baf3b9a846ebe