### PR TITLE
Handle module load errors by clearing loading state

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,6 +462,10 @@
                             rej(err);
                             showModuleError(src);
                             reject(err);
+                            window.appLoading = false;
+                            hideLoadingOverlay();
+                            delete window.modulePromises[src];
+                            return;
                         };
                         document.body.appendChild(s);
                     });


### PR DESCRIPTION
## Summary
- Stop app loading overlay when a module fails to load
- Allow retrying `loadApp()` after module load failure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:ids`

------
https://chatgpt.com/codex/tasks/task_b_68b0be6f0aec8332a6a3a5957a28002a