### PR TITLE
Fix module loader preventing QR generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,27 +472,6 @@
                             };
                             s.onerror = tryLoad;
                             document.body.appendChild(s);
-
-                    window.modulePromises[src] = new Promise((res, rej) => {
-                        const s = document.createElement('script');
-                        s.src = src;
-                        s.onload = () => {
-                            window.loadedModules = window.loadedModules || {};
-                            window.loadedModules[src] = true;
-                            res();
-                            document.dispatchEvent(new CustomEvent('moduleLoaded', { detail: { src } }));
-                            loadNext();
-                        };
-                        s.onerror = () => {
-                            const err = new Error(`Failed to load ${src}`);
-                            rej(err);
-                            showModuleError(src);
-                            reject(err);
-                            window.appLoading = false;
-                            hideLoadingOverlay();
-                            delete window.modulePromises[src];
-                            return;
-
                         };
                         tryLoad();
                     });


### PR DESCRIPTION
## Summary
- Correct sequential script loader to reliably load required modules
- Ensures QR libraries load so QR code creation works

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0c00fb46c8332b377ea3e8f5fc6cf