### PR TITLE
Load CDN QR libraries first

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains the iKey web application and related assets. All of the
 
 ### Offline Dependencies
 
-For offline use, place `qrcode.min.js` and `jsQR.min.js` in a `vendor/` directory and ensure they are bundled with the application. The loader will attempt to use these local copies first and fall back to the CDN versions if they are missing.
+For offline use, place `qrcode.min.js` and `jsQR.min.js` in a `vendor/` directory and ensure they are bundled with the application. The loader will try the CDN versions first and fall back to these local copies if the CDN is unavailable.
 
 ## Dashboard
 

--- a/index.html
+++ b/index.html
@@ -429,8 +429,8 @@
             window.appLoading = true;
             showLoadingOverlay();
             const scripts = [
-                ['vendor/qrcode.min.js', 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js'],
-                ['vendor/jsQR.min.js', 'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js'],
+                ['https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js', 'vendor/qrcode.min.js'],
+                ['https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js', 'vendor/jsQR.min.js'],
                 'app.js',
                 'medication.js',
                 'text-size.js',


### PR DESCRIPTION
## Summary
- load QR and jsQR libraries from CDN first to prevent 404s when vendor copies missing
- document new CDN-first fallback behavior in README

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0c16939d8833298d447b07d63089c