### PR TITLE
Handle v2 QR hash format in viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,8 +1103,18 @@
         function parseUrlParameters() {
             let guid, key, name, created;
 
-            // Check hash first (new format: #guid|key|name|created)
+            // Check hash first
             const hash = window.location.hash.substring(1);
+
+            // Newer format: #v2:guid:key
+            if (hash.startsWith('v2:')) {
+                const parts = hash.split(':');
+                guid = decodeURIComponent(parts[1] || '');
+                key = decodeURIComponent(parts[2] || '');
+                return { guid, key, name, created };
+            }
+
+            // Legacy format: #guid|key|name|created
             if (hash && hash.includes('|')) {
                 [guid, key, name, created] = hash.split('|').map(decodeURIComponent);
                 return { guid, key, name, created };


### PR DESCRIPTION
## Summary
- support `#v2:guid:key` URLs when parsing QR hashes
- maintain compatibility with legacy `guid|key|name|created` links

## Testing
- `npm run lint:ids`

------
https://chatgpt.com/codex/tasks/task_b_68b0f80bad7883328aa510819e548fc8