### PR TITLE
Use four-part QR fragments

### DIFF
--- a/app-standalone.html
+++ b/app-standalone.html
@@ -307,16 +307,31 @@
                 return;
             }
 
-            // Handle legacy format and v2 encoded hashes
-            if (!hash.startsWith('v2:')) {
-                return handleLegacyFormat(hash);
+            if (hash.includes('|')) {
+                const parts = hash.split('|').map(decodeURIComponent);
+                if (parts.length >= 4) {
+                    const [guid, key, name, created] = parts;
+                    currentGUID = guid;
+                    currentKey = key;
+                    currentMode = 'view';
+                    await loadAndDisplayEmergencyInfo(guid, key, name, created);
+                } else {
+                    handleLegacyFormat(hash);
+                }
+                return;
             }
 
-            const [version, guid, key] = hash.split(':');
-            currentGUID = guid;
-            currentKey = key;
-            currentMode = 'view';
-            await loadAndDisplayEmergencyInfo(guid, key, null, null);
+            if (hash.startsWith('v2:')) {
+                const [version, guid, key] = hash.split(':');
+                currentGUID = guid;
+                currentKey = key;
+                currentMode = 'view';
+                await loadAndDisplayEmergencyInfo(guid, key, null, null);
+                return;
+            }
+
+            currentMode = 'create';
+            showCreationForm();
         }
 
         async function displayFullInfo(full) {
@@ -1719,8 +1734,8 @@
                 updateSourceLabel();
 
                 // Only generate QR after successful upload
-                const qrUrl = `${VIEWER_URL}#v2:${currentGUID}:${currentKey}`;
-                window.location.hash = `v2:${currentGUID}:${currentKey}`;
+                const qrUrl = `${VIEWER_URL}#${currentGUID}|${currentKey}|${encodeURIComponent(formData.name)}|${created}`;
+                window.location.hash = `${currentGUID}|${currentKey}|${encodeURIComponent(formData.name)}|${created}`;
 
                 // Generate QR code
                 const qrContainer = document.getElementById('qrcode');
@@ -2059,7 +2074,9 @@
         }
 
         function viewQR() {
-            const url = window.currentQRUrl || `${VIEWER_URL}#v2:${currentGUID}:${currentKey}`;
+            const created = currentBlob?.created || new Date().toISOString();
+            const name = currentBlob?.name || '';
+            const url = window.currentQRUrl || `${VIEWER_URL}#${currentGUID}|${currentKey}|${encodeURIComponent(name)}|${created}`;
             const existing = document.getElementById('qr-viewer');
             if (existing) existing.remove();
             const overlay = document.createElement('div');
@@ -2077,7 +2094,9 @@
 
         function downloadQRFixed() {
             const canvas = document.querySelector('#qrcode canvas, #owner-qr canvas');
-            const url = window.currentQRUrl || `${VIEWER_URL}#v2:${currentGUID}:${currentKey}`;
+            const created = currentBlob?.created || new Date().toISOString();
+            const name = currentBlob?.name || '';
+            const url = window.currentQRUrl || `${VIEWER_URL}#${currentGUID}|${currentKey}|${encodeURIComponent(name)}|${created}`;
             if (!canvas) {
                 const tempDiv = document.createElement('div');
                 new QRCode(tempDiv, {
@@ -2103,7 +2122,9 @@
         }
 
         function shareQR() {
-            const url = window.currentQRUrl || `${VIEWER_URL}#v2:${currentGUID}:${currentKey}`;
+            const created = currentBlob?.created || new Date().toISOString();
+            const name = currentBlob?.name || '';
+            const url = window.currentQRUrl || `${VIEWER_URL}#${currentGUID}|${currentKey}|${encodeURIComponent(name)}|${created}`;
             if (navigator.share && url) {
                 navigator.share({ title: 'iKey', url }).catch(() => {});
             } else if (url) {
@@ -2262,7 +2283,10 @@
 
         function parseQRData(text) {
             let guid, key;
-            if (text.includes('v2:')) {
+            if (text.includes('#') && text.includes('|')) {
+                const hash = text.split('#')[1];
+                [guid, key] = hash.split('|');
+            } else if (text.includes('v2:')) {
                 const hash = text.split('#')[1];
                 const parts = hash.split(':');
                 guid = parts[1];

--- a/index.html
+++ b/index.html
@@ -1106,17 +1106,17 @@
             // Check hash first
             const hash = window.location.hash.substring(1);
 
-            // Newer format: #v2:guid:key
+            // Four-part format: #guid|key|name|created
+            if (hash && hash.includes('|')) {
+                [guid, key, name, created] = hash.split('|').map(decodeURIComponent);
+                return { guid, key, name, created };
+            }
+
+            // Legacy v2 format: v2:guid:key
             if (hash.startsWith('v2:')) {
                 const parts = hash.split(':');
                 guid = decodeURIComponent(parts[1] || '');
                 key = decodeURIComponent(parts[2] || '');
-                return { guid, key, name, created };
-            }
-
-            // Legacy format: #guid|key|name|created
-            if (hash && hash.includes('|')) {
-                [guid, key, name, created] = hash.split('|').map(decodeURIComponent);
                 return { guid, key, name, created };
             }
 

--- a/personal.html
+++ b/personal.html
@@ -85,9 +85,11 @@
     document.getElementById('generate').addEventListener('click', () => {
       const guid = crypto.randomUUID();
       const key = generateKey();
-        const url = `${VIEWER_URL}#v2:${guid}:${key}`;
-        currentQRUrl = url;
-        const qrDiv = document.getElementById('qrcode');
+      const name = prompt('Name for QR:', '') || '';
+      const createdISO = new Date().toISOString();
+      const url = `${VIEWER_URL}#${guid}|${key}|${encodeURIComponent(name)}|${createdISO}`;
+      currentQRUrl = url;
+      const qrDiv = document.getElementById('qrcode');
       qrDiv.innerHTML = '';
       new QRCode(qrDiv, {
         text: url,


### PR DESCRIPTION
## Summary
- replace `#v2:` QR links with `#guid|key|encodeURIComponent(name)|createdISO`
- parse four-fragment hashes in the viewer and app while retaining legacy `v2:` support
- propagate full fragment format through QR view, download, and share utilities

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0f9e316548332af0b6321a4013cdb