### PR TITLE
Add single QR wizard launch from bulk page

### DIFF
--- a/bulk.html
+++ b/bulk.html
@@ -63,13 +63,20 @@
     <p>Select a CSV file to begin generating QR codes.</p>
     <input type="file" id="bulk-file" accept=".csv">
     <div id="file-info"></div>
+    <div style="margin-top: 20px;">
+      <button id="single-qr-btn">Create Single QR</button>
+    </div>
   </div>
   <script>
     const fileInput = document.getElementById('bulk-file');
     const info = document.getElementById('file-info');
+    const singleBtn = document.getElementById('single-qr-btn');
     fileInput.addEventListener('change', () => {
       const file = fileInput.files[0];
       info.textContent = file ? `Selected: ${file.name}` : '';
+    });
+    singleBtn.addEventListener('click', () => {
+      window.location.href = 'index.html?create=1';
     });
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -1230,6 +1230,13 @@
 
         // Initialize on page load
         window.addEventListener('DOMContentLoaded', async function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            if (urlParams.get('create') === '1') {
+                currentMode = 'create';
+                showCreationForm();
+                return;
+            }
+
             const { guid, key, name, created } = parseUrlParameters();
             console.log('Parsed parameters:', { guid, key, name, created });
 


### PR DESCRIPTION
## Summary
- Add "Create Single QR" button to bulk generation page
- Support `?create=1` query parameter on index to auto-open PIN setup wizard

## Testing
- `npm run lint:ids`

------
https://chatgpt.com/codex/tasks/task_b_68b0fd96352883328b295dd562ccc132