### PR TITLE
fix: remove stray await causing syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,13 +1541,6 @@
             return until > Date.now() ? until - Date.now() : 0;
         }
 
-
-            try {
-                const hash = await sha256Hash(currentBlob.passwordSalt + password);
-                if (!currentBlob.privateInfo || hash !== currentBlob.privateInfo.encryptedWith) {
-                    throw new Error('Incorrect password');
-                }
-
         function registerFailure(key) {
             const attempts = Number(sessionStorage.getItem(key) || '0') + 1;
             const delay = Math.min(2 ** attempts, 32) * 1000;


### PR DESCRIPTION
## Summary
- Remove leftover top-level `await` block that triggered a SyntaxError
- Keep backoff helpers intact for PIN/password checks

## Testing
- `npm run lint:ids`


------
https://chatgpt.com/codex/tasks/task_b_68b0ff5b89548332a81f9b10c343209e